### PR TITLE
Make confidence optional in PoseEstimationSeries

### DIFF
--- a/spec/ndx-pose.extensions.yaml
+++ b/spec/ndx-pose.extensions.yaml
@@ -32,6 +32,7 @@ groups:
     - null
     doc: Confidence or likelihood of the estimated positions, scaled to be between
       0 and 1.
+    quantity: '?'
     attributes:
     - name: definition
       dtype: text

--- a/src/pynwb/ndx_pose/pose.py
+++ b/src/pynwb/ndx_pose/pose.py
@@ -23,8 +23,9 @@ class PoseEstimationSeries(SpatialSeries):
          'doc': ('Estimated position (x, y) or (x, y, z).')},
         {'name': 'reference_frame', 'type': str,   # required
          'doc': 'Description defining what the zero-position (0, 0) or (0, 0, 0) is.'},
-        {'name': 'confidence', 'type': ('array_data', 'data'), 'shape': (None, ),  # required
-         'doc': ('Confidence or likelihood of the estimated positions, scaled to be between 0 and 1.')},
+        {'name': 'confidence', 'type': ('array_data', 'data'), 'shape': (None, ), 
+         'doc': ('Confidence or likelihood of the estimated positions, scaled to be between 0 and 1.'),
+          'default': None,},
         {'name': 'unit', 'type': str,
          'doc': ("Base unit of measurement for working with the data. The default value "
                  "is 'pixels'. Actual stored values are not necessarily stored in these units. "


### PR DESCRIPTION
Sometimes the data for confidence is not available but nevertheless we want to be able to build a PoseEstimationSeries. Making confidence optional is better than introducing fake values and was discussed with @bendichter as an option. The goal of this PR is to make confidence an optional value. So far, I have changed the docval and the schema. Is there anything else that should be changed or added?s