### PR TITLE
Handle new warning message format from hdmf 4.1.0

### DIFF
--- a/src/pynwb/tests/back_compat/test_read.py
+++ b/src/pynwb/tests/back_compat/test_read.py
@@ -19,6 +19,11 @@ def get_io(path):
             message=r"Ignoring cached namespace .*",
             category=UserWarning,
         )
+        warnings.filterwarnings(
+            "ignore",
+            message=r"Ignoring the following cached namespace(s) .*",
+            category=UserWarning,
+        )
         return NWBHDF5IO(str(path), "r")
 
 


### PR DESCRIPTION
HDMF 4.1.0 changed the format of the cached namespace warning, which is checked for in the backwards compatibility tests. It now looks like:
```
/home/runner/work/ndx-pose/ndx-pose/src/pynwb/tests/back_compat/0.1.1_poseestimation_nodes_edges.nwb: Ignoring the following cached namespace(s) because another version is already loaded:
core - cached version: 2.7.0, loaded version: 2.8.0
ndx-pose - cached version: 0.1.1, loaded version: 0.2.0
The loaded extension(s) may not be compatible with the cached extension(s) in the file. Please check the extension documentation and ignore this warning if these versions are compatible.
```