### PR TITLE
Fix dependency problems

### DIFF
--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -22,23 +22,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-python3.8-minimum      , requirements: minimum    , python-ver: "3.8" , os: ubuntu-latest }
-          - { name: linux-python3.8              , requirements: upgraded   , python-ver: "3.8" , os: ubuntu-latest }
-          - { name: linux-python3.9              , requirements: upgraded   , python-ver: "3.9" , os: ubuntu-latest }
+          - { name: linux-python3.10-minimum     , requirements: minimum    , python-ver: "3.10", os: ubuntu-latest }
           - { name: linux-python3.10             , requirements: upgraded   , python-ver: "3.10", os: ubuntu-latest }
           - { name: linux-python3.11             , requirements: upgraded   , python-ver: "3.11", os: ubuntu-latest }
           - { name: linux-python3.12             , requirements: upgraded   , python-ver: "3.12", os: ubuntu-latest }
           - { name: linux-python3.13             , requirements: upgraded   , python-ver: "3.13", os: ubuntu-latest }
-          - { name: windows-python3.8-minimum    , requirements: minimum    , python-ver: "3.8" , os: windows-latest }
-          - { name: windows-python3.8            , requirements: upgraded   , python-ver: "3.8" , os: windows-latest }
-          - { name: windows-python3.9            , requirements: upgraded   , python-ver: "3.9" , os: windows-latest }
+          - { name: windows-python3.10-minimum   , requirements: minimum    , python-ver: "3.10", os: windows-latest }
           - { name: windows-python3.10           , requirements: upgraded   , python-ver: "3.10", os: windows-latest }
           - { name: windows-python3.11           , requirements: upgraded   , python-ver: "3.11", os: windows-latest }
           - { name: windows-python3.12           , requirements: upgraded   , python-ver: "3.12", os: windows-latest }
           - { name: windows-python3.13           , requirements: upgraded   , python-ver: "3.13", os: windows-latest }
-          - { name: macos-python3.8-minimum      , requirements: minimum    , python-ver: "3.8" , os: macos-latest }
-          - { name: macos-python3.8              , requirements: upgraded   , python-ver: "3.8" , os: macos-latest }
-          - { name: macos-python3.9              , requirements: upgraded   , python-ver: "3.9" , os: macos-latest }
+          - { name: macos-python3.10-minimum     , requirements: minimum    , python-ver: "3.10", os: macos-latest }
           - { name: macos-python3.10             , requirements: upgraded   , python-ver: "3.10", os: macos-latest }
           - { name: macos-python3.11             , requirements: upgraded   , python-ver: "3.11", os: macos-latest }
           - { name: macos-python3.12             , requirements: upgraded   , python-ver: "3.12", os: macos-latest }
@@ -58,7 +52,7 @@ jobs:
         if: ${{ matrix.requirements == 'minimum' }}
         run: |
           python -m pip install --upgrade pip
-          python -m pip install ".[min-reqs,test]"
+          python -m pip install . --group min-reqs --group test
           python -m pip list
           python -m pip check
 
@@ -67,7 +61,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           # force upgrade of all dependencies to latest versions within allowed range
-          python -m pip install -U ".[test]"
+          python -m pip install -U . --group test
           python -m pip list
           python -m pip check
       - name: Run tests

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           # force upgrade of all dependencies to latest versions within allowed range
-          python -m pip install -U ".[test]"
+          python -m pip install -U . --group test
           python -m pip list
           python -m pip check
       - name: Run tests and generate coverage report

--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,4 @@ cython_debug/
 
 # Mac finder
 .DS_Store
+uv.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,8 @@ keywords = [
     'ndx-extension',
 ]
 dependencies = [
-    "pynwb>=3.0.0",  # 3.0.0 compatible with hdmf 4.0+ and numpy 2.0
-    "hdmf>=4.0.0",  # 4.0.0 required for numpy 2.0 compatibility 
+    "pynwb>=2.6.0",
+    "hdmf>=3.13.0",
 ]
 
 # Dependency groups (PEP 735) - for development, not published to PyPI
@@ -62,10 +62,11 @@ dev = [
     {include-group = "docs"},
     {include-group = "test"},
 ]
-# minimum requirements of project dependencies for testing (see .github/workflows/run_all_tests.yml)
+# minimum requirements of project dependencies for testing on Python 3.10 (see .github/workflows/run_all_tests.yml)
 min-reqs = [
-    "pynwb==3.0.0",
-    "hdmf==4.0.0",
+    "pynwb==2.6.0; python_version == '3.10'",
+    "hdmf==3.13.0; python_version == '3.10'",
+    "numpy<2; python_version == '3.10'",
 ]
 
 # TODO: add URLs before release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,10 @@ authors = [
 ]
 description = "NWB extension to store pose estimation data"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = {text = "BSD-3"}
 classifiers = [
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -40,11 +38,12 @@ keywords = [
     'ndx-extension',
 ]
 dependencies = [
-    "pynwb>=2.6.0",
-    "hdmf>=3.13.0",
+    "pynwb>=3.0.0",  # 3.0.0 compatible with hdmf 4.0+ and numpy 2.0
+    "hdmf>=4.0.0",  # 4.0.0 required for numpy 2.0 compatibility 
 ]
 
-[project.optional-dependencies]
+# Dependency groups (PEP 735) - for development, not published to PyPI
+[dependency-groups]
 test = [
     "coverage>=7.5.4",
     "pytest>=8.2.2",
@@ -52,23 +51,21 @@ test = [
     "pytest-subtests>=0.12.1",
     "python-dateutil>=2.8.2",
 ]
-
 docs = [
     "hdmf-docutils>=0.4.7",
 ]
-
 dev = [
     "black>=24.4.2",
     "codespell>=2.3.0",
     "pre-commit>=3.5.0",
     "ruff>=0.4.10",
-    "ndx-pose[docs,test]",
+    {include-group = "docs"},
+    {include-group = "test"},
 ]
-
 # minimum requirements of project dependencies for testing (see .github/workflows/run_all_tests.yml)
 min-reqs = [
-    "pynwb==2.6.0",
-    "hdmf==3.13.0",
+    "pynwb==3.0.0",
+    "hdmf==4.0.0",
 ]
 
 # TODO: add URLs before release


### PR DESCRIPTION
This PR makes three changes:

**1. Fix NumPy 2.0 compatibility by updating minimum dependencies**

The problem manifests when a user installs ndx-pose on Python 3.10+ with the old minimum dependencies (`pynwb==2.6.0`, `hdmf==3.13.0`). Since pip resolves the newest compatible versions of transitive dependencies, it installs NumPy 2.0+ (released June 2024), which removed `np.string_` in favor of `np.bytes_`. However, neither `pynwb==2.6.0` nor `hdmf==3.13.0` pin NumPy<2.0 or contain fixes for NumPy 2.0 compatibility - hdmf didn't add NumPy 2.0 support until version 4.0.0 (released January 2025). This causes a runtime `AttributeError` when reading/writing NWB files. The fix is to bump the minimum dependencies to `hdmf>=4.0.0` and `pynwb>=3.0.0` (the first pynwb compatible with hdmf 4.0+), ensuring any installation gets NumPy 2.0-compatible code.

**2. Drop Python 3.8 and 3.9 support**

Python 3.8 reached end-of-life in October 2024 and Python 3.9 reaches end-of-life in October 2025. This PR updates the minimum Python version to 3.10 and removes 3.8/3.9 from the CI test matrix.

**3. Use PEP 735 dependency groups**

Migrates from `[project.optional-dependencies]` to `[dependency-groups]` as specified in [PEP 735](https://peps.python.org/pep-0735/). 
