### PR TITLE
Add `source_video` link field to PoseEstimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Upcoming
 
-The 0.2.0 schema has not changed, but the surrounding infrastructure and Python API has changes:
+### Schema changes
+- Added optional `source_video` and `labeled_video` links on `PoseEstimation` that reference an `ImageSeries`
+  in the NWBFile, providing a formal alternative to the fragile string paths in `original_videos` and
+  `labeled_videos`. @h-mayorquin (#56)
 
 ### Bug fixes
 - Tests were updated to account for a change in the format of warnings from HDMF 4.1.0. @rly (#49)

--- a/spec/ndx-pose.extensions.yaml
+++ b/spec/ndx-pose.extensions.yaml
@@ -84,7 +84,9 @@ groups:
     shape:
     - null
     doc: Paths to the original video files. The number of files should equal the number
-      of camera devices.
+      of camera devices. Note that these string paths might be fragile unless relative
+      paths are used and care is taken to keep them consistent. Consider using the
+      'source_video' link instead for a formal reference.
     quantity: '?'
   - name: labeled_videos
     dtype: text
@@ -130,6 +132,13 @@ groups:
   - target_type: Device
     doc: Cameras used to record the videos.
     quantity: '*'
+  - name: source_video
+    target_type: ImageSeries
+    doc: Link to an ImageSeries containing the source video used for pose estimation.
+      The ImageSeries should be stored in the NWBFile (e.g., in acquisition).
+      When available, this field should be preferred over 'original_videos' as it
+      provides a formal reference rather than a file path string.
+    quantity: '?'
 - neurodata_type_def: TrainingFrame
   neurodata_type_inc: NWBDataInterface
   default_name: TrainingFrame

--- a/spec/ndx-pose.extensions.yaml
+++ b/spec/ndx-pose.extensions.yaml
@@ -95,7 +95,9 @@ groups:
     shape:
     - null
     doc: Paths to the labeled video files. The number of files should equal the number
-      of camera devices.
+      of camera devices. Note that these string paths might be fragile unless relative
+      paths are used and care is taken to keep them consistent. Consider using the
+      'labeled_video' link instead for a formal reference.
     quantity: '?'
   - name: dimensions
     dtype: uint8
@@ -138,6 +140,14 @@ groups:
       The ImageSeries should be stored in the NWBFile (e.g., in acquisition).
       When available, this field should be preferred over 'original_videos' as it
       provides a formal reference rather than a file path string.
+    quantity: '?'
+  - name: labeled_video
+    target_type: ImageSeries
+    doc: Link to an ImageSeries containing the labeled video (with pose estimation
+      overlays) produced from the source video. The ImageSeries should be stored
+      in the NWBFile (e.g., in acquisition). When available, this field should be
+      preferred over 'labeled_videos' as it provides a formal reference rather than
+      a file path string.
     quantity: '?'
 - neurodata_type_def: TrainingFrame
   neurodata_type_inc: NWBDataInterface

--- a/spec/ndx-pose.namespace.yaml
+++ b/spec/ndx-pose.namespace.yaml
@@ -22,4 +22,4 @@ namespaces:
   schema:
   - namespace: core
   - source: ndx-pose.extensions.yaml
-  version: 0.2.0
+  version: 0.2.1

--- a/src/pynwb/ndx_pose/pose.py
+++ b/src/pynwb/ndx_pose/pose.py
@@ -3,6 +3,7 @@ from hdmf.utils import docval, popargs, get_docval, AllowPositional
 from pynwb import register_class, TimeSeries, get_class
 from pynwb.behavior import SpatialSeries
 from pynwb.core import MultiContainerInterface
+from pynwb.image import ImageSeries
 
 # TODO validate Skeleton nodes and edges correspondence, convert edges to uint
 # TODO validate that all Skeleton nodes are used in edges
@@ -120,6 +121,7 @@ class PoseEstimation(MultiContainerInterface):
         "nodes",
         "edges",
         "skeleton",  # <-- this is a link to a Skeleton object
+        "source_video",  # <-- this is a link to an ImageSeries object
     )
 
     # custom mapper in ndx_pose.io.pose maps:
@@ -149,7 +151,11 @@ class PoseEstimation(MultiContainerInterface):
             "name": "original_videos",
             "type": ("array_data", "data"),
             "shape": (None,),
-            "doc": "Paths to the original video files. The number of files should equal the number of camera devices.",
+            "doc": (
+                "Paths to the original video files. The number of files should equal the number of camera devices. "
+                "Note: these string paths might be fragile unless relative paths are used and care is taken to "
+                "keep them consistent. Consider using 'source_video' instead for a formal link to an ImageSeries."
+            ),
             "default": None,
         },
         {
@@ -204,6 +210,17 @@ class PoseEstimation(MultiContainerInterface):
             "default": None,
         },
         {
+            "name": "source_video",
+            "type": ImageSeries,
+            "doc": (
+                "Link to an ImageSeries containing the source video used for pose estimation. "
+                "The ImageSeries should be stored in the NWBFile (e.g., in acquisition) and linked here. "
+                "When available, this field should be preferred over 'original_videos' as it provides "
+                "a formal reference rather than a file path string."
+            ),
+            "default": None,
+        },
+        {
             "name": "nodes",
             "type": ("array_data", "data"),
             "doc": (
@@ -226,7 +243,7 @@ class PoseEstimation(MultiContainerInterface):
         allow_positional=AllowPositional.ERROR,
     )
     def __init__(self, **kwargs):
-        nodes, edges, skeleton = popargs("nodes", "edges", "skeleton", kwargs)
+        nodes, edges, skeleton, source_video = popargs("nodes", "edges", "skeleton", "source_video", kwargs)
         if nodes is not None or edges is not None:
             if skeleton is not None:
                 raise ValueError("Cannot specify 'skeleton' with 'nodes' or 'edges'.")
@@ -296,6 +313,7 @@ class PoseEstimation(MultiContainerInterface):
         self.source_software = source_software
         self.source_software_version = source_software_version
         self.skeleton = skeleton
+        self.source_video = source_video
 
         # TODO include calibration images for 3D estimates?
         # TODO validate that the nodes correspond to the names of the pose estimation series objects

--- a/src/pynwb/ndx_pose/pose.py
+++ b/src/pynwb/ndx_pose/pose.py
@@ -122,6 +122,7 @@ class PoseEstimation(MultiContainerInterface):
         "edges",
         "skeleton",  # <-- this is a link to a Skeleton object
         "source_video",  # <-- this is a link to an ImageSeries object
+        "labeled_video",  # <-- this is a link to an ImageSeries object
     )
 
     # custom mapper in ndx_pose.io.pose maps:
@@ -162,7 +163,11 @@ class PoseEstimation(MultiContainerInterface):
             "name": "labeled_videos",
             "type": ("array_data", "data"),
             "shape": (None,),
-            "doc": "Paths to the labeled video files. The number of files should equal the number of camera devices.",
+            "doc": (
+                "Paths to the labeled video files. The number of files should equal the number of camera devices. "
+                "Note: these string paths might be fragile unless relative paths are used and care is taken to "
+                "keep them consistent. Consider using 'labeled_video' instead for a formal link to an ImageSeries."
+            ),
             "default": None,
         },
         {
@@ -221,6 +226,17 @@ class PoseEstimation(MultiContainerInterface):
             "default": None,
         },
         {
+            "name": "labeled_video",
+            "type": ImageSeries,
+            "doc": (
+                "Link to an ImageSeries containing the labeled video (with pose estimation overlays) "
+                "produced from the source video. The ImageSeries should be stored in the NWBFile "
+                "(e.g., in acquisition) and linked here. When available, this field should be preferred "
+                "over 'labeled_videos' as it provides a formal reference rather than a file path string."
+            ),
+            "default": None,
+        },
+        {
             "name": "nodes",
             "type": ("array_data", "data"),
             "doc": (
@@ -243,7 +259,9 @@ class PoseEstimation(MultiContainerInterface):
         allow_positional=AllowPositional.ERROR,
     )
     def __init__(self, **kwargs):
-        nodes, edges, skeleton, source_video = popargs("nodes", "edges", "skeleton", "source_video", kwargs)
+        nodes, edges, skeleton, source_video, labeled_video = popargs(
+            "nodes", "edges", "skeleton", "source_video", "labeled_video", kwargs
+        )
         if nodes is not None or edges is not None:
             if skeleton is not None:
                 raise ValueError("Cannot specify 'skeleton' with 'nodes' or 'edges'.")
@@ -314,6 +332,7 @@ class PoseEstimation(MultiContainerInterface):
         self.source_software_version = source_software_version
         self.skeleton = skeleton
         self.source_video = source_video
+        self.labeled_video = labeled_video
 
         # TODO include calibration images for 3D estimates?
         # TODO validate that the nodes correspond to the names of the pose estimation series objects

--- a/src/pynwb/ndx_pose/testing/mock/pose.py
+++ b/src/pynwb/ndx_pose/testing/mock/pose.py
@@ -92,6 +92,7 @@ def mock_PoseEstimation(
     source_software: Optional[str] = "DeepLabCut",
     source_software_version: Optional[str] = "2.2b8",
     source_video: Optional[ImageSeries] = None,
+    labeled_video: Optional[ImageSeries] = None,
 ):
     """Create a mock PoseEstimation object.
 
@@ -111,6 +112,7 @@ def mock_PoseEstimation(
         source_software_version=source_software_version,
         skeleton=skeleton,
         source_video=source_video,
+        labeled_video=labeled_video,
     )
 
     if nwbfile is not None:

--- a/src/pynwb/ndx_pose/testing/mock/pose.py
+++ b/src/pynwb/ndx_pose/testing/mock/pose.py
@@ -91,6 +91,7 @@ def mock_PoseEstimation(
     scorer: Optional[str] = "DLC_resnet50_openfieldOct30shuffle1_1600",
     source_software: Optional[str] = "DeepLabCut",
     source_software_version: Optional[str] = "2.2b8",
+    source_video: Optional[ImageSeries] = None,
 ):
     """Create a mock PoseEstimation object.
 
@@ -109,6 +110,7 @@ def mock_PoseEstimation(
         source_software=source_software,
         source_software_version=source_software_version,
         skeleton=skeleton,
+        source_video=source_video,
     )
 
     if nwbfile is not None:

--- a/src/pynwb/tests/integration/hdf5/test_pose.py
+++ b/src/pynwb/tests/integration/hdf5/test_pose.py
@@ -2,6 +2,7 @@ import datetime
 import numpy as np
 
 from pynwb import NWBHDF5IO, NWBFile
+from pynwb.image import ImageSeries
 from pynwb.testing import TestCase, remove_test_file, NWBH5IOFlexMixin
 
 from ndx_pose import (
@@ -187,6 +188,66 @@ class TestPoseEstimationRoundtrip(TestCase):
             self.assertContainerEqual(read_pe.skeleton, skeleton)
             self.assertEqual(len(read_pe.devices), 1)
             self.assertContainerEqual(read_pe.devices[0], self.nwbfile.devices["camera1"])
+
+
+class TestPoseEstimationRoundtripSourceVideo(TestCase):
+    """Roundtrip test for PoseEstimation with source_video link."""
+
+    def setUp(self):
+        self.nwbfile = NWBFile(
+            session_description="session_description",
+            identifier="identifier",
+            session_start_time=datetime.datetime.now(datetime.timezone.utc),
+        )
+        self.nwbfile.create_device(name="camera1")
+        self.path = "test_pose.nwb"
+
+    def tearDown(self):
+        remove_test_file(self.path)
+
+    def test_roundtrip(self):
+        """Test that source_video link survives write/read roundtrip."""
+        source_video = ImageSeries(
+            name="source_video",
+            description="Source video for pose estimation.",
+            unit="NA",
+            format="external",
+            external_file=["camera1.mp4"],
+            dimension=[640, 480],
+            starting_frame=[0],
+            rate=30.0,
+        )
+        self.nwbfile.add_acquisition(source_video)
+
+        skeleton = mock_Skeleton()
+        skeletons = Skeletons(skeletons=[skeleton])
+
+        pose_estimation_series = [mock_PoseEstimationSeries(name=name) for name in skeleton.nodes]
+        pe = PoseEstimation(
+            pose_estimation_series=pose_estimation_series,
+            description="Estimated positions of front paws using DeepLabCut.",
+            original_videos=["camera1.mp4"],
+            dimensions=np.array([[640, 480]], dtype="uint16"),
+            devices=[self.nwbfile.devices["camera1"]],
+            scorer="DLC_resnet50_openfieldOct30shuffle1_1600",
+            source_software="DeepLabCut",
+            source_software_version="2.2b8",
+            skeleton=skeleton,
+            source_video=source_video,
+        )
+
+        behavior_pm = self.nwbfile.create_processing_module(name="behavior", description="processed behavioral data")
+        behavior_pm.add(pe)
+        behavior_pm.add(skeletons)
+
+        with NWBHDF5IO(self.path, mode="w") as io:
+            io.write(self.nwbfile)
+
+        with NWBHDF5IO(self.path, mode="r", load_namespaces=True) as io:
+            read_nwbfile = io.read()
+            read_pe = read_nwbfile.processing["behavior"]["PoseEstimation"]
+            self.assertContainerEqual(read_pe.source_video, source_video)
+            self.assertEqual(read_pe.source_video.external_file[0], "camera1.mp4")
 
 
 class TestPoseEstimationRoundtripPyNWB(NWBH5IOFlexMixin, TestCase):

--- a/src/pynwb/tests/integration/hdf5/test_pose.py
+++ b/src/pynwb/tests/integration/hdf5/test_pose.py
@@ -250,6 +250,66 @@ class TestPoseEstimationRoundtripSourceVideo(TestCase):
             self.assertEqual(read_pe.source_video.external_file[0], "camera1.mp4")
 
 
+class TestPoseEstimationRoundtripLabeledVideo(TestCase):
+    """Roundtrip test for PoseEstimation with labeled_video link."""
+
+    def setUp(self):
+        self.nwbfile = NWBFile(
+            session_description="session_description",
+            identifier="identifier",
+            session_start_time=datetime.datetime.now(datetime.timezone.utc),
+        )
+        self.nwbfile.create_device(name="camera1")
+        self.path = "test_pose.nwb"
+
+    def tearDown(self):
+        remove_test_file(self.path)
+
+    def test_roundtrip(self):
+        """Test that labeled_video link survives write/read roundtrip."""
+        labeled_video = ImageSeries(
+            name="labeled_video",
+            description="Labeled video produced from pose estimation.",
+            unit="NA",
+            format="external",
+            external_file=["camera1_labeled.mp4"],
+            dimension=[640, 480],
+            starting_frame=[0],
+            rate=30.0,
+        )
+        self.nwbfile.add_acquisition(labeled_video)
+
+        skeleton = mock_Skeleton()
+        skeletons = Skeletons(skeletons=[skeleton])
+
+        pose_estimation_series = [mock_PoseEstimationSeries(name=name) for name in skeleton.nodes]
+        pe = PoseEstimation(
+            pose_estimation_series=pose_estimation_series,
+            description="Estimated positions of front paws using DeepLabCut.",
+            labeled_videos=["camera1_labeled.mp4"],
+            dimensions=np.array([[640, 480]], dtype="uint16"),
+            devices=[self.nwbfile.devices["camera1"]],
+            scorer="DLC_resnet50_openfieldOct30shuffle1_1600",
+            source_software="DeepLabCut",
+            source_software_version="2.2b8",
+            skeleton=skeleton,
+            labeled_video=labeled_video,
+        )
+
+        behavior_pm = self.nwbfile.create_processing_module(name="behavior", description="processed behavioral data")
+        behavior_pm.add(pe)
+        behavior_pm.add(skeletons)
+
+        with NWBHDF5IO(self.path, mode="w") as io:
+            io.write(self.nwbfile)
+
+        with NWBHDF5IO(self.path, mode="r", load_namespaces=True) as io:
+            read_nwbfile = io.read()
+            read_pe = read_nwbfile.processing["behavior"]["PoseEstimation"]
+            self.assertContainerEqual(read_pe.labeled_video, labeled_video)
+            self.assertEqual(read_pe.labeled_video.external_file[0], "camera1_labeled.mp4")
+
+
 class TestPoseEstimationRoundtripPyNWB(NWBH5IOFlexMixin, TestCase):
     """Complex, more complete roundtrip test for PoseEstimation using pynwb.testing infrastructure."""
 

--- a/src/pynwb/tests/unit/test_pose.py
+++ b/src/pynwb/tests/unit/test_pose.py
@@ -6,6 +6,8 @@ from pynwb.device import Device
 from pynwb.testing import TestCase
 from pynwb.file import Subject
 
+from pynwb.image import ImageSeries
+
 from ndx_pose import (
     PoseEstimationSeries,
     Skeleton,
@@ -226,6 +228,45 @@ class TestPoseEstimationConstructor(TestCase):
         self.assertEqual(pe.skeleton.name, skeleton.name)
         self.assertEqual(pe.skeleton.nodes, skeleton.nodes)
         np.testing.assert_array_equal(pe.skeleton.edges, skeleton.edges)
+
+    def test_constructor_source_video(self):
+        """Test that source_video link is set correctly."""
+        source_video = ImageSeries(
+            name="source_video",
+            description="Source video for pose estimation.",
+            unit="NA",
+            format="external",
+            external_file=["camera1.mp4"],
+            dimension=[640, 480],
+            starting_frame=[0],
+            rate=30.0,
+        )
+        skeleton = mock_Skeleton()
+        pose_estimation_series = [mock_PoseEstimationSeries(name=name) for name in skeleton.nodes]
+
+        pe = PoseEstimation(
+            pose_estimation_series=pose_estimation_series,
+            description="Estimated positions of front paws using DeepLabCut.",
+            original_videos=["camera1.mp4"],
+            devices=[self.nwbfile.devices["camera1"]],
+            scorer="DLC_resnet50_openfieldOct30shuffle1_1600",
+            source_software="DeepLabCut",
+            source_software_version="2.2b8",
+            skeleton=skeleton,
+            source_video=source_video,
+        )
+        self.assertIs(pe.source_video, source_video)
+
+    def test_constructor_source_video_default_none(self):
+        """Test that source_video defaults to None."""
+        skeleton = mock_Skeleton()
+        pose_estimation_series = [mock_PoseEstimationSeries(name=name) for name in skeleton.nodes]
+
+        pe = PoseEstimation(
+            pose_estimation_series=pose_estimation_series,
+            skeleton=skeleton,
+        )
+        self.assertIsNone(pe.source_video)
 
 
 class TestSkeletonInstance(TestCase):

--- a/src/pynwb/tests/unit/test_pose.py
+++ b/src/pynwb/tests/unit/test_pose.py
@@ -268,6 +268,45 @@ class TestPoseEstimationConstructor(TestCase):
         )
         self.assertIsNone(pe.source_video)
 
+    def test_constructor_labeled_video(self):
+        """Test that labeled_video link is set correctly."""
+        labeled_video = ImageSeries(
+            name="labeled_video",
+            description="Labeled video produced from pose estimation.",
+            unit="NA",
+            format="external",
+            external_file=["camera1_labeled.mp4"],
+            dimension=[640, 480],
+            starting_frame=[0],
+            rate=30.0,
+        )
+        skeleton = mock_Skeleton()
+        pose_estimation_series = [mock_PoseEstimationSeries(name=name) for name in skeleton.nodes]
+
+        pe = PoseEstimation(
+            pose_estimation_series=pose_estimation_series,
+            description="Estimated positions of front paws using DeepLabCut.",
+            labeled_videos=["camera1_labeled.mp4"],
+            devices=[self.nwbfile.devices["camera1"]],
+            scorer="DLC_resnet50_openfieldOct30shuffle1_1600",
+            source_software="DeepLabCut",
+            source_software_version="2.2b8",
+            skeleton=skeleton,
+            labeled_video=labeled_video,
+        )
+        self.assertIs(pe.labeled_video, labeled_video)
+
+    def test_constructor_labeled_video_default_none(self):
+        """Test that labeled_video defaults to None."""
+        skeleton = mock_Skeleton()
+        pose_estimation_series = [mock_PoseEstimationSeries(name=name) for name in skeleton.nodes]
+
+        pe = PoseEstimation(
+            pose_estimation_series=pose_estimation_series,
+            skeleton=skeleton,
+        )
+        self.assertIsNone(pe.labeled_video)
+
 
 class TestSkeletonInstance(TestCase):
     def test_constructor(self):

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -16,7 +16,7 @@ def main():
     ns_builder = NWBNamespaceBuilder(
         doc="NWB extension to store pose estimation data",
         name="ndx-pose",
-        version="0.2.0",
+        version="0.2.1",
         author=[
             "Ryan Ly",
             "Ben Dichter",
@@ -167,6 +167,28 @@ def main():
                 doc="Cameras used to record the videos.",
                 quantity="*",
             ),
+            NWBLinkSpec(
+                name="source_video",
+                target_type="ImageSeries",
+                doc=(
+                    "Link to an ImageSeries containing the source video used for pose estimation. The "
+                    "ImageSeries should be stored in the NWBFile (e.g., in acquisition). When available, this "
+                    "field should be preferred over 'original_videos' as it provides a formal reference rather "
+                    "than a file path string."
+                ),
+                quantity="?",
+            ),
+            NWBLinkSpec(
+                name="labeled_video",
+                target_type="ImageSeries",
+                doc=(
+                    "Link to an ImageSeries containing the labeled video (with pose estimation overlays) "
+                    "produced from the source video. The ImageSeries should be stored in the NWBFile (e.g., in "
+                    "acquisition). When available, this field should be preferred over 'labeled_videos' as it "
+                    "provides a formal reference rather than a file path string."
+                ),
+                quantity="?",
+            ),
         ],
         datasets=[
             NWBDatasetSpec(
@@ -177,7 +199,12 @@ def main():
             ),
             NWBDatasetSpec(
                 name="original_videos",
-                doc="Paths to the original video files. The number of files should equal the number of camera devices.",
+                doc=(
+                    "Paths to the original video files. The number of files should equal the number of camera "
+                    "devices. Note that these string paths might be fragile unless relative paths are used and "
+                    "care is taken to keep them consistent. Consider using the 'source_video' link instead for "
+                    "a formal reference."
+                ),
                 dtype="text",
                 dims=["num_files"],
                 shape=[None],
@@ -185,7 +212,12 @@ def main():
             ),
             NWBDatasetSpec(
                 name="labeled_videos",
-                doc="Paths to the labeled video files. The number of files should equal the number of camera devices.",
+                doc=(
+                    "Paths to the labeled video files. The number of files should equal the number of camera "
+                    "devices. Note that these string paths might be fragile unless relative paths are used and "
+                    "care is taken to keep them consistent. Consider using the 'labeled_video' link instead for "
+                    "a formal reference."
+                ),
                 dtype="text",
                 dims=["num_files"],
                 shape=[None],


### PR DESCRIPTION
Adds an optional `source_video` link to `ImageSeries` on `PoseEstimation`, consistent with how [`TrainingFrame` already links to its source video](https://github.com/rly/ndx-pose/blob/a5e4c2e1a2ef0f86df06963258bd5dabe19c1483/spec/ndx-pose.extensions.yaml#L153-L157). This provides a formal NWB reference to the source video instead of relying on the string paths in `original_videos`, which can become stale or break when files are moved (e.g., [dandi/dandi-cli#1817](https://github.com/dandi/dandi-cli/issues/1817)). 

Closes #12 and supersedes #13 with a simpler approach that requires no custom IO mapper.

To discuss: the current approach keeps `original_videos` is kept for backwards compatibility but I am unsure if we should remove this and bumpb the schema source. I think we can leep it here and decide this later 
