### PR TITLE
Add Python 3.14 testing, refresh metadata, and fix review findings

### DIFF
--- a/.github/workflows/check_external_links.yml
+++ b/.github/workflows/check_external_links.yml
@@ -26,8 +26,7 @@ jobs:
       - name: Install Sphinx dependencies and package
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -U ".[docs]"
-          python -m pip install .
+          python -m pip install -U . --group docs
 
       - name: Check Sphinx external links
         run: |

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -27,16 +27,19 @@ jobs:
           - { name: linux-python3.11             , requirements: upgraded   , python-ver: "3.11", os: ubuntu-latest }
           - { name: linux-python3.12             , requirements: upgraded   , python-ver: "3.12", os: ubuntu-latest }
           - { name: linux-python3.13             , requirements: upgraded   , python-ver: "3.13", os: ubuntu-latest }
+          - { name: linux-python3.14             , requirements: upgraded   , python-ver: "3.14", os: ubuntu-latest }
           - { name: windows-python3.10-minimum   , requirements: minimum    , python-ver: "3.10", os: windows-latest }
           - { name: windows-python3.10           , requirements: upgraded   , python-ver: "3.10", os: windows-latest }
           - { name: windows-python3.11           , requirements: upgraded   , python-ver: "3.11", os: windows-latest }
           - { name: windows-python3.12           , requirements: upgraded   , python-ver: "3.12", os: windows-latest }
           - { name: windows-python3.13           , requirements: upgraded   , python-ver: "3.13", os: windows-latest }
+          - { name: windows-python3.14           , requirements: upgraded   , python-ver: "3.14", os: windows-latest }
           - { name: macos-python3.10-minimum     , requirements: minimum    , python-ver: "3.10", os: macos-latest }
           - { name: macos-python3.10             , requirements: upgraded   , python-ver: "3.10", os: macos-latest }
           - { name: macos-python3.11             , requirements: upgraded   , python-ver: "3.11", os: macos-latest }
           - { name: macos-python3.12             , requirements: upgraded   , python-ver: "3.12", os: macos-latest }
           - { name: macos-python3.13             , requirements: upgraded   , python-ver: "3.13", os: macos-latest }
+          - { name: macos-python3.14             , requirements: upgraded   , python-ver: "3.14", os: macos-latest }
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@
 ### Bug fixes
 - Tests were updated to account for a change in the format of warnings from HDMF 4.1.0. @rly (#49)
 - Improved documentation. @h-mayorquin (#50)
+- Fixed the docstring of the `PoseEstimation` `name` constructor argument, which duplicated the `description`
+  docstring. @rly
+- `PoseEstimation.nodes` and `PoseEstimation.edges` now raise an informative error instead of an `AttributeError`
+  when the object has no `Skeleton`. @rly
+- Fixed `mock_source_frame` to generate a name when none is provided, instead of passing `None` to `RGBImage`. @rly
+
+### Minor updates
+- Added testing on Python 3.14 and the corresponding PyPI classifier. @rly
+- Updated copyright dates to 2026 and aligned the author lists in `LICENSE.txt` and the docs with `pyproject.toml`.
+  @rly
+- Removed the obsolete `importlib_resources` import fallback and added the missing `ndx_pose.testing` package init.
+  @rly
+- Removed placeholder project URLs from `pyproject.toml`. @rly
 
 
 ## ndx-pose 0.2.2 (May 7, 2025)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,18 +11,18 @@
 - Tests were updated to account for a change in the format of warnings from HDMF 4.1.0. @rly (#49)
 - Improved documentation. @h-mayorquin (#50)
 - Fixed the docstring of the `PoseEstimation` `name` constructor argument, which duplicated the `description`
-  docstring. @rly
+  docstring. @rly (#58)
 - `PoseEstimation.nodes` and `PoseEstimation.edges` now raise an informative error instead of an `AttributeError`
-  when the object has no `Skeleton`. @rly
-- Fixed `mock_source_frame` to generate a name when none is provided, instead of passing `None` to `RGBImage`. @rly
+  when the object has no `Skeleton`. @rly (#58)
+- Fixed `mock_source_frame` to generate a name when none is provided, instead of passing `None` to `RGBImage`. @rly (#58)
 
 ### Minor updates
-- Added testing on Python 3.14 and the corresponding PyPI classifier. @rly
+- Added testing on Python 3.14 and the corresponding PyPI classifier. @rly (#58)
 - Updated copyright dates to 2026 and aligned the author lists in `LICENSE.txt` and the docs with `pyproject.toml`.
-  @rly
+  @rly (#58)
 - Removed the obsolete `importlib_resources` import fallback and added the missing `ndx_pose.testing` package init.
-  @rly
-- Removed placeholder project URLs from `pyproject.toml`. @rly
+  @rly (#58)
+- Removed placeholder project URLs from `pyproject.toml`. @rly (#58)
 
 
 ## ndx-pose 0.2.2 (May 7, 2025)

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2021-2024, Ryan Ly, Ben Dichter, Alexander Mathis, Liezl Maree, Chris Brozdowski, Heberto Mayorquin, Talmo Pereira, Elizabeth Berrigan
+Copyright (c) 2021-2026, Ryan Ly, Ben Dichter, Alexander Mathis, Liezl Maree, Chris Brozdowski, Heberto Mayorquin, Talmo Pereira, Elizabeth Berrigan, Paul Adkisson
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,11 +7,11 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = 'ndx-pose'
-copyright = '2024, Ryan Ly, Ben Dichter, Alexander Mathis, Liezl Maree, Chris Brozdowski, Heberto Mayorquin, Talmo Pereira, Elizabeth Berrigan'
-author = 'Ryan Ly, Ben Dichter, Alexander Mathis, Liezl Maree, Chris Brozdowski, Heberto Mayorquin, Talmo Pereira, Elizabeth Berrigan'
+copyright = '2021-2026, Ryan Ly, Ben Dichter, Alexander Mathis, Liezl Maree, Chris Brozdowski, Heberto Mayorquin, Talmo Pereira, Elizabeth Berrigan, Paul Adkisson'
+author = 'Ryan Ly, Ben Dichter, Alexander Mathis, Liezl Maree, Chris Brozdowski, Heberto Mayorquin, Talmo Pereira, Elizabeth Berrigan, Paul Adkisson'
 
-version = '0.2.0'
-release = '0.2.0'
+version = '0.2.2'
+release = '0.2.2'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
@@ -69,12 +70,9 @@ min-reqs = [
     "numpy<2; python_version == '3.10'",
 ]
 
-# TODO: add URLs before release
 [project.urls]
 "Homepage" = "https://github.com/rly/ndx-pose"
-# "Documentation" = "https://package.readthedocs.io/"
 "Bug Tracker" = "https://github.com/rly/ndx-pose/issues"
-# "Discussions" = "https://github.com/organization/package/discussions"
 "Changelog" = "https://github.com/rly/ndx-pose/blob/main/CHANGELOG.md"
 
 # Include only the source code under `src/pynwb/ndx_pose` and the spec files under `spec`

--- a/src/pynwb/ndx_pose/__init__.py
+++ b/src/pynwb/ndx_pose/__init__.py
@@ -1,11 +1,7 @@
 import os
-from pynwb import load_namespaces
+from importlib.resources import files
 
-try:
-    from importlib.resources import files
-except ImportError:
-    # TODO: Remove when python 3.9 becomes the new minimum
-    from importlib_resources import files
+from pynwb import load_namespaces
 
 # Get path to the namespace.yaml file with the expected location when installed not in editable mode
 __location_of_this_file = files(__name__)

--- a/src/pynwb/ndx_pose/pose.py
+++ b/src/pynwb/ndx_pose/pose.py
@@ -139,7 +139,7 @@ class PoseEstimation(MultiContainerInterface):
         {
             "name": "name",
             "type": str,
-            "doc": "Description of the pose estimation procedure and output.",
+            "doc": "Name of this PoseEstimation object.",
             "default": "PoseEstimation",
         },
         {
@@ -339,6 +339,11 @@ class PoseEstimation(MultiContainerInterface):
 
     @property
     def nodes(self):
+        if self.skeleton is None:
+            raise ValueError(
+                "This PoseEstimation object has no Skeleton, so it has no nodes. Provide a 'skeleton' argument "
+                "to access nodes via PoseEstimation.skeleton.nodes."
+            )
         return self.skeleton.nodes
 
     @nodes.setter
@@ -349,6 +354,11 @@ class PoseEstimation(MultiContainerInterface):
 
     @property
     def edges(self):
+        if self.skeleton is None:
+            raise ValueError(
+                "This PoseEstimation object has no Skeleton, so it has no edges. Provide a 'skeleton' argument "
+                "to access edges via PoseEstimation.skeleton.edges."
+            )
         return self.skeleton.edges
 
     @edges.setter

--- a/src/pynwb/ndx_pose/testing/mock/pose.py
+++ b/src/pynwb/ndx_pose/testing/mock/pose.py
@@ -115,15 +115,14 @@ def mock_PoseEstimation(
         labeled_video=labeled_video,
     )
 
-    if nwbfile is not None:
-        skeletons = Skeletons(skeletons=[skeleton])
+    skeletons = Skeletons(skeletons=[skeleton])
 
-        if "behavior" not in nwbfile.processing:
-            behavior_pm = nwbfile.create_processing_module(name="behavior", description="processed behavioral data")
-        else:
-            behavior_pm = nwbfile.processing["behavior"]
-        behavior_pm.add(pe)
-        behavior_pm.add(skeletons)
+    if "behavior" not in nwbfile.processing:
+        behavior_pm = nwbfile.create_processing_module(name="behavior", description="processed behavioral data")
+    else:
+        behavior_pm = nwbfile.processing["behavior"]
+    behavior_pm.add(pe)
+    behavior_pm.add(skeletons)
 
     return pe
 
@@ -198,7 +197,7 @@ def mock_source_frame(
     *,
     name: Optional[str] = None,
 ):
-    return RGBImage(name=name, data=np.random.rand(640, 480, 3).astype("uint8"))
+    return RGBImage(name=name or name_generator("RGBImage"), data=np.random.rand(640, 480, 3).astype("uint8"))
 
 
 def mock_TrainingFrame(


### PR DESCRIPTION
## Summary
- Adds Python 3.14 to the test matrix (linux/windows/macOS, upgraded requirements) and the PyPI classifier list.
- Refreshes project metadata: copyright dates to 2026, aligns the author lists in `LICENSE.txt` and `docs/source/conf.py` with `pyproject.toml` (adds Paul Adkisson), and updates the docs version to 0.2.2.
- Removes the obsolete `importlib_resources` import fallback (minimum Python is 3.10) and adds the missing `ndx_pose.testing` package `__init__.py`.
- Removes placeholder project URLs and a stale TODO from `pyproject.toml`.

## Bug fixes from a codebase review
- Fixed the `PoseEstimation` `name` argument docstring, which duplicated the `description` docstring.
- `PoseEstimation.nodes` / `.edges` now raise an informative `ValueError` instead of an `AttributeError` when the object has no `Skeleton`.
- `mock_PoseEstimation`: dropped the dead `nwbfile is not None` guard (the argument is required).
- `mock_source_frame`: generates a name when none is provided instead of passing `None` to `RGBImage`.

## Testing
- `ruff check` clean; full suite passes locally (31 tests, 277 subtests) on Python 3.12 with pynwb 3.1.3 / hdmf 4.3.1.
- The new Python 3.14 jobs use the "upgraded" requirements path; if pynwb/hdmf/h5py do not yet publish cp314 wheels, those jobs may need to build from source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)