### PR TITLE
Bump GitHub Actions, target Python 3.14, and fix docs/README issues

### DIFF
--- a/.github/workflows/check_external_links.yml
+++ b/.github/workflows/check_external_links.yml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install Sphinx dependencies and package
         run: |

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -12,6 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Codespell
         uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -12,6 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Ruff
-        uses: astral-sh/ruff-action@v3
+        uses: astral-sh/ruff-action@v4

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -14,4 +14,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Ruff
-        uses: astral-sh/ruff-action@v4
+        uses: astral-sh/ruff-action@v4.0.0  # no moving v4 major tag is published yet

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -42,12 +42,12 @@ jobs:
           - { name: macos-python3.14             , requirements: upgraded   , python-ver: "3.14", os: macos-latest }
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-ver }}
 

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -24,15 +24,15 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     env:  # used by codecov-action
       OS: ${{ matrix.os }}
-      PYTHON: '3.13'
+      PYTHON: '3.14'
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON }}
 
@@ -49,7 +49,7 @@ jobs:
 
       # TODO uncomment after setting up repo on codecov.io and adding token
       # - name: Upload coverage to Codecov
-      #   uses: codecov/codecov-action@v4
+      #   uses: codecov/codecov-action@v6
       #   with:
       #     fail_ci_if_error: true
       #     file: ./coverage.xml

--- a/.github/workflows/validate_schema.yml
+++ b/.github/workflows/validate_schema.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install HDMF
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
   when the object has no `Skeleton`. @rly (#58)
 - Fixed `mock_source_frame` to generate a name when none is provided, instead of passing `None` to `RGBImage`. @rly (#58)
 - Documented the `source_video` and `labeled_video` links on `PoseEstimation` in the README diagrams and corrected
-  the `source_software` field name (previously shown as `scorer_software`). @rly (#XX)
+  the `source_software` field name (previously shown as `scorer_software`). @rly (#59)
 
 ### Minor updates
 - Added testing on Python 3.14 and the corresponding PyPI classifier. @rly (#58)
@@ -26,9 +26,9 @@
   @rly (#58)
 - Removed placeholder project URLs from `pyproject.toml`. @rly (#58)
 - Updated GitHub Actions to current major versions (`checkout` v6, `setup-python` v6, `ruff-action` v4,
-  `codecov-action` v6) and switched the single-version workflows to Python 3.14. @rly (#XX)
+  `codecov-action` v6) and switched the single-version workflows to Python 3.14. @rly (#59)
 - Removed the deprecated `sphinx_rtd_theme.get_html_theme_path()` call from the docs config and registered the
-  theme via `extensions`. @rly (#XX)
+  theme via `extensions`. @rly (#59)
 
 
 ## ndx-pose 0.2.2 (May 7, 2025)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@
 - `PoseEstimation.nodes` and `PoseEstimation.edges` now raise an informative error instead of an `AttributeError`
   when the object has no `Skeleton`. @rly (#58)
 - Fixed `mock_source_frame` to generate a name when none is provided, instead of passing `None` to `RGBImage`. @rly (#58)
-- Documented the `source_video` and `labeled_video` links on `PoseEstimation` in the README diagrams and corrected
-  the `source_software` field name (previously shown as `scorer_software`). @rly (#59)
+- Documented the `source_video` and `labeled_video` links on `PoseEstimation` in the README diagrams and the
+  pose-estimation example, and corrected the `source_software` field name (previously shown as `scorer_software`).
+  @rly (#59)
 
 ### Minor updates
 - Added testing on Python 3.14 and the corresponding PyPI classifier. @rly (#58)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - `PoseEstimation.nodes` and `PoseEstimation.edges` now raise an informative error instead of an `AttributeError`
   when the object has no `Skeleton`. @rly (#58)
 - Fixed `mock_source_frame` to generate a name when none is provided, instead of passing `None` to `RGBImage`. @rly (#58)
+- Documented the `source_video` and `labeled_video` links on `PoseEstimation` in the README diagrams and corrected
+  the `source_software` field name (previously shown as `scorer_software`). @rly (#XX)
 
 ### Minor updates
 - Added testing on Python 3.14 and the corresponding PyPI classifier. @rly (#58)
@@ -23,6 +25,10 @@
 - Removed the obsolete `importlib_resources` import fallback and added the missing `ndx_pose.testing` package init.
   @rly (#58)
 - Removed placeholder project URLs from `pyproject.toml`. @rly (#58)
+- Updated GitHub Actions to current major versions (`checkout` v6, `setup-python` v6, `ruff-action` v4,
+  `codecov-action` v6) and switched the single-version workflows to Python 3.14. @rly (#XX)
+- Removed the deprecated `sphinx_rtd_theme.get_html_theme_path()` call from the docs config and registered the
+  theme via `extensions`. @rly (#XX)
 
 
 ## ndx-pose 0.2.2 (May 7, 2025)

--- a/README.md
+++ b/README.md
@@ -110,11 +110,13 @@ classDiagram
             labeled_videos : array[str; dims [file]], optional
             dimensions : array[uint, dims [file, [width, height]]], optional
             scorer : str, optional
-            scorer_software : str, optional
-            scorer_software__version : str, optional
+            source_software : str, optional
+            source_software__version : str, optional
             PoseEstimationSeries
             Skeleton, link
             Device, link
+            source_video : ImageSeries, link, optional
+            labeled_video : ImageSeries, link, optional
         }
 
         class Skeletons {
@@ -133,10 +135,12 @@ classDiagram
     }
 
     class Device
+    class ImageSeries
 
     PoseEstimation --o PoseEstimationSeries : contains 0 or more
     PoseEstimation --> Skeleton : links to
     PoseEstimation --> Device : links to
+    PoseEstimation --> ImageSeries : links to
     Skeletons --o Skeleton : contains 0 or more
 ```
 
@@ -166,11 +170,13 @@ classDiagram
             labeled_videos : array[str; dims [file]], optional
             dimensions : array[uint, dims [file, [width, height]]], optional
             scorer : str, optional
-            scorer_software : str, optional
-            scorer_software__version : str, optional
+            source_software : str, optional
+            source_software__version : str, optional
             PoseEstimationSeries
             Skeleton, link
             Device, link
+            source_video : ImageSeries, link, optional
+            labeled_video : ImageSeries, link, optional
         }
 
         class Skeleton {
@@ -233,6 +239,7 @@ classDiagram
     PoseEstimation --o PoseEstimationSeries : contains 0 or more
     PoseEstimation --> Skeleton : links to
     PoseEstimation --> Device : links to
+    PoseEstimation --> ImageSeries : links to
 
     PoseTraining --o TrainingFrames : contains
     PoseTraining --o SourceVideos : contains

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,6 +20,7 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
+    'sphinx_rtd_theme',
 ]
 
 templates_path = ['_templates']
@@ -45,7 +46,6 @@ intersphinx_mapping = {
 #  CUSTOM CONFIGURATIONS ADDED BY THE NWB TOOL FOR GENERATING FORMAT DOCS
 ###########################################################################
 
-import sphinx_rtd_theme  # noqa: E402
 import textwrap  # noqa: E402
 
 # -- Options for intersphinx  ---------------------------------------------
@@ -91,7 +91,6 @@ add_function_parentheses = False
 
 # -- HTML sphinx options
 html_theme = "sphinx_rtd_theme"
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # LaTeX Sphinx options
 latex_elements = {

--- a/examples/write_pose_estimates_only.py
+++ b/examples/write_pose_estimates_only.py
@@ -9,6 +9,7 @@ import datetime
 import numpy as np
 from pynwb import NWBFile, NWBHDF5IO
 from pynwb.file import Subject
+from pynwb.image import ImageSeries
 from ndx_pose import (
     PoseEstimationSeries,
     PoseEstimation,
@@ -47,6 +48,32 @@ camera1 = nwbfile.create_device(
     description="camera for recording behavior",
     manufacturer="my manufacturer",
 )
+
+# create ImageSeries that point to the source and labeled video files and add them to the NWBFile.
+# the PoseEstimation object links to these below via 'source_video' and 'labeled_video', providing a formal
+# reference to the videos instead of relying only on the string paths in 'original_videos'/'labeled_videos'.
+source_video = ImageSeries(
+    name="source_video",
+    description="Video recorded by camera1 and used for pose estimation.",
+    unit="NA",
+    format="external",
+    external_file=["path/to/camera1.mp4"],
+    dimension=[640, 480],
+    starting_frame=[0],
+    rate=30.0,
+)
+labeled_video = ImageSeries(
+    name="labeled_video",
+    description="Video with pose estimation overlays produced from the source video.",
+    unit="NA",
+    format="external",
+    external_file=["path/to/camera1_labeled.mp4"],
+    dimension=[640, 480],
+    starting_frame=[0],
+    rate=30.0,
+)
+nwbfile.add_acquisition(source_video)
+nwbfile.add_acquisition(labeled_video)
 
 # a PoseEstimationSeries represents the estimated position of a single marker.
 # in this example, we have three PoseEstimationSeries: one for the body and one for each front paw.
@@ -97,8 +124,7 @@ front_right_paw = PoseEstimationSeries(
 pose_estimation_series = [front_left_paw, body, front_right_paw]
 
 # create a PoseEstimation object that represents the estimated positions of each node, references
-# the original video and labeled video files, and provides metadata on how these estimates were generated.
-# multiple videos and cameras can be referenced.
+# the source and labeled videos, and provides metadata on how these estimates were generated.
 pose_estimation = PoseEstimation(
     name="PoseEstimation",
     pose_estimation_series=pose_estimation_series,
@@ -111,6 +137,8 @@ pose_estimation = PoseEstimation(
     source_software="DeepLabCut",
     source_software_version="2.3.8",
     skeleton=skeleton,  # link to the skeleton object
+    source_video=source_video,  # link to the source video ImageSeries
+    labeled_video=labeled_video,  # link to the labeled video ImageSeries
 )
 
 # create a "behavior" processing module to store the PoseEstimation and Skeletons objects
@@ -130,5 +158,8 @@ with NWBHDF5IO(path, mode="w") as io:
 # as well as the first training frame
 with NWBHDF5IO(path, mode="r") as io:
     read_nwbfile = io.read()
-    print(read_nwbfile.processing["behavior"]["PoseEstimation"])
+    read_pose_estimation = read_nwbfile.processing["behavior"]["PoseEstimation"]
+    print(read_pose_estimation)
     print(read_nwbfile.processing["behavior"]["Skeletons"]["subject1_skeleton"])
+    # the 'source_video' link resolves to the ImageSeries stored in acquisition
+    print(read_pose_estimation.source_video)


### PR DESCRIPTION
## Summary
- Bumps GitHub Actions to current major versions (`actions/checkout` v6, `actions/setup-python` v6, `astral-sh/ruff-action` v4, `codecov/codecov-action` v6; `codespell-project/actions-codespell` stays at its latest major, v2). This moves the previously Node 20 actions onto Node 24, resolving the deprecation notice.
- Switches the single-version workflows (coverage, external links, schema validation) to Python 3.14.
- Removes the deprecated `sphinx_rtd_theme.get_html_theme_path()` call from `docs/source/conf.py` and registers the theme via `extensions`, eliminating the linkcheck deprecation warning.
- Documents the `source_video` / `labeled_video` links on `PoseEstimation` in the README diagrams and corrects the `source_software` field name (was shown as `scorer_software`).

## Verification (Python 3.14.5)
- Confirmed pynwb 3.1.3 / hdmf 4.3.1 / h5py 3.16.0 / numpy 2.4.6 all install with cp314 wheels.
- `ruff check` clean; full suite passes (31 tests, 277 subtests).
- `sphinx-build -b linkcheck` and `-b html` both build with **0 warnings** (the deprecation warning is gone) and all external links report `ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)