### PR TITLE
Regenerate YAML and prepare release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
   `codecov-action` v6) and switched the single-version workflows to Python 3.14. @rly (#59)
 - Removed the deprecated `sphinx_rtd_theme.get_html_theme_path()` call from the docs config and registered the
   theme via `extensions`. @rly (#59)
+- Regenerated the spec YAML files with the latest `ruamel.yaml`, which changed the line wrapping of the docstrings.
+  The schema content is unchanged. @rly (#60)
 
 
 ## ndx-pose 0.2.2 (May 7, 2025)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
   theme via `extensions`. @rly (#59)
 - Regenerated the spec YAML files with the latest `ruamel.yaml`, which changed the line wrapping of the docstrings.
   The schema content is unchanged. @rly (#60)
+- Documented the development installation (`pip install -e . --group dev`) in the README. @rly (#60)
 
 
 ## ndx-pose 0.2.2 (May 7, 2025)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for ndx-pose
 
-## Upcoming
+## ndx-pose 0.3.0 (June 2, 2026)
 
 ### Schema changes
 - Added optional `source_video` and `labeled_video` links on `PoseEstimation` that reference an `ImageSeries`

--- a/README.md
+++ b/README.md
@@ -37,6 +37,21 @@ named "behavior", as shown below.
 ```bash
 pip install "ndx-pose"
 ```
+
+### Development installation
+
+Development dependencies are defined as [PEP 735](https://peps.python.org/pep-0735/) dependency groups in
+`pyproject.toml`. Installing them requires pip 25.1 or later. To set up an editable install with the development
+tools (tests, docs, and linters), run:
+
+```bash
+git clone https://github.com/rly/ndx-pose.git
+cd ndx-pose
+pip install -e . --group dev
+```
+
+The `test`, `docs`, and `min-reqs` groups can be installed individually with `pip install -e . --group <name>`.
+
 ## Usage examples
 
 1. [Example writing pose estimates (keypoints) to an NWB file](examples/write_pose_estimates_only.py).

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,8 +10,8 @@ project = 'ndx-pose'
 copyright = '2021-2026, Ryan Ly, Ben Dichter, Alexander Mathis, Liezl Maree, Chris Brozdowski, Heberto Mayorquin, Talmo Pereira, Elizabeth Berrigan, Paul Adkisson'
 author = 'Ryan Ly, Ben Dichter, Alexander Mathis, Liezl Maree, Chris Brozdowski, Heberto Mayorquin, Talmo Pereira, Elizabeth Berrigan, Paul Adkisson'
 
-version = '0.2.2'
-release = '0.2.2'
+version = '0.3.0'
+release = '0.3.0'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ndx-pose"
-version = "0.2.2"
+version = "0.3.0"
 authors = [
     { name="Ryan Ly", email="rly@lbl.gov" },
     { name="Ben Dichter", email="bdichter@lbl.gov" },

--- a/spec/ndx-pose.extensions.yaml
+++ b/spec/ndx-pose.extensions.yaml
@@ -1,8 +1,8 @@
 groups:
 - neurodata_type_def: Skeleton
   neurodata_type_inc: NWBDataInterface
-  doc: Group that holds node and edge data for defining parts of a pose and their
-    connections to one another. Names should be unique in a file.
+  doc: Group that holds node and edge data for defining parts of a pose and
+    their connections to one another. Names should be unique in a file.
   datasets:
   - name: nodes
     dtype: text
@@ -10,8 +10,8 @@ groups:
     - num_body_parts
     shape:
     - null
-    doc: Array of body part names corresponding to the names of the PoseEstimationSeries
-      objects or PoseTraining objects.
+    doc: Array of body part names corresponding to the names of the
+      PoseEstimationSeries objects or PoseTraining objects.
   - name: edges
     dtype: uint8
     dims:
@@ -20,12 +20,14 @@ groups:
     shape:
     - null
     - 2
-    doc: Array of pairs of indices corresponding to edges between nodes. Index values
-      correspond to row indices of the 'nodes' dataset. Index values use 0-indexing.
+    doc: Array of pairs of indices corresponding to edges between nodes. Index
+      values correspond to row indices of the 'nodes' dataset. Index values use
+      0-indexing.
     quantity: '?'
   links:
   - target_type: Subject
-    doc: The Subject object in the NWB file, if this Skeleton corresponds to the Subject.
+    doc: The Subject object in the NWB file, if this Skeleton corresponds to the
+      Subject.
     quantity: '?'
 - neurodata_type_def: PoseEstimationSeries
   neurodata_type_inc: SpatialSeries
@@ -48,9 +50,10 @@ groups:
     - name: unit
       dtype: text
       default_value: pixels
-      doc: Base unit of measurement for working with the data. The default value is
-        'pixels'. Actual stored values are not necessarily stored in these units.
-        To access the data in these units, multiply 'data' by 'conversion'.
+      doc: Base unit of measurement for working with the data. The default value
+        is 'pixels'. Actual stored values are not necessarily stored in these
+        units. To access the data in these units, multiply 'data' by
+        'conversion'.
       required: false
   - name: confidence
     dtype: float32
@@ -58,20 +61,20 @@ groups:
     - num_frames
     shape:
     - null
-    doc: Confidence or likelihood of the estimated positions, scaled to be between
-      0 and 1.
+    doc: Confidence or likelihood of the estimated positions, scaled to be
+      between 0 and 1.
     attributes:
     - name: definition
       dtype: text
-      doc: Description of how the confidence was computed, e.g., 'Softmax output of
-        the deep neural network'.
+      doc: Description of how the confidence was computed, e.g., 'Softmax output
+        of the deep neural network'.
       required: false
 - neurodata_type_def: PoseEstimation
   neurodata_type_inc: NWBDataInterface
   default_name: PoseEstimation
-  doc: Group that holds estimated position data for multiple body parts, computed
-    from the same video with the same tool/algorithm. The timestamps of each child
-    PoseEstimationSeries type should be the same.
+  doc: Group that holds estimated position data for multiple body parts,
+    computed from the same video with the same tool/algorithm. The timestamps of
+    each child PoseEstimationSeries type should be the same.
   datasets:
   - name: description
     dtype: text
@@ -83,10 +86,10 @@ groups:
     - num_files
     shape:
     - null
-    doc: Paths to the original video files. The number of files should equal the number
-      of camera devices. Note that these string paths might be fragile unless relative
-      paths are used and care is taken to keep them consistent. Consider using the
-      'source_video' link instead for a formal reference.
+    doc: Paths to the original video files. The number of files should equal the
+      number of camera devices. Note that these string paths might be fragile
+      unless relative paths are used and care is taken to keep them consistent.
+      Consider using the 'source_video' link instead for a formal reference.
     quantity: '?'
   - name: labeled_videos
     dtype: text
@@ -94,10 +97,10 @@ groups:
     - num_files
     shape:
     - null
-    doc: Paths to the labeled video files. The number of files should equal the number
-      of camera devices. Note that these string paths might be fragile unless relative
-      paths are used and care is taken to keep them consistent. Consider using the
-      'labeled_video' link instead for a formal reference.
+    doc: Paths to the labeled video files. The number of files should equal the
+      number of camera devices. Note that these string paths might be fragile
+      unless relative paths are used and care is taken to keep them consistent.
+      Consider using the 'labeled_video' link instead for a formal reference.
     quantity: '?'
   - name: dimensions
     dtype: uint8
@@ -115,8 +118,8 @@ groups:
     quantity: '?'
   - name: source_software
     dtype: text
-    doc: Name of the software tool used. Specifying the version attribute is strongly
-      encouraged.
+    doc: Name of the software tool used. Specifying the version attribute is
+      strongly encouraged.
     quantity: '?'
     attributes:
     - name: version
@@ -136,24 +139,25 @@ groups:
     quantity: '*'
   - name: source_video
     target_type: ImageSeries
-    doc: Link to an ImageSeries containing the source video used for pose estimation.
-      The ImageSeries should be stored in the NWBFile (e.g., in acquisition).
-      When available, this field should be preferred over 'original_videos' as it
-      provides a formal reference rather than a file path string.
+    doc: Link to an ImageSeries containing the source video used for pose
+      estimation. The ImageSeries should be stored in the NWBFile (e.g., in
+      acquisition). When available, this field should be preferred over
+      'original_videos' as it provides a formal reference rather than a file
+      path string.
     quantity: '?'
   - name: labeled_video
     target_type: ImageSeries
-    doc: Link to an ImageSeries containing the labeled video (with pose estimation
-      overlays) produced from the source video. The ImageSeries should be stored
-      in the NWBFile (e.g., in acquisition). When available, this field should be
-      preferred over 'labeled_videos' as it provides a formal reference rather than
-      a file path string.
+    doc: Link to an ImageSeries containing the labeled video (with pose
+      estimation overlays) produced from the source video. The ImageSeries
+      should be stored in the NWBFile (e.g., in acquisition). When available,
+      this field should be preferred over 'labeled_videos' as it provides a
+      formal reference rather than a file path string.
     quantity: '?'
 - neurodata_type_def: TrainingFrame
   neurodata_type_inc: NWBDataInterface
   default_name: TrainingFrame
-  doc: Group that holds ground-truth position data for all instances of a skeleton
-    in a single frame.
+  doc: Group that holds ground-truth position data for all instances of a
+    skeleton in a single frame.
   attributes:
   - name: annotator
     dtype: text
@@ -161,29 +165,31 @@ groups:
     required: false
   - name: source_video_frame_index
     dtype: uint8
-    doc: Frame index of training frame in the original video `source_video`. If provided,
-      then `source_video` is required.
+    doc: Frame index of training frame in the original video `source_video`. If
+      provided, then `source_video` is required.
     required: false
   groups:
   - name: skeleton_instances
     neurodata_type_inc: SkeletonInstances
-    doc: Position data for all instances of a skeleton in a single training frame.
+    doc: Position data for all instances of a skeleton in a single training
+      frame.
   links:
   - name: source_video
     target_type: ImageSeries
-    doc: Link to an ImageSeries representing a video of training frames (stored internally
-      or externally). Required if `source_video_frame_index` is provided.
+    doc: Link to an ImageSeries representing a video of training frames (stored
+      internally or externally). Required if `source_video_frame_index` is
+      provided.
     quantity: '?'
   - name: source_frame
     target_type: Image
-    doc: Link to an internally stored image representing the training frame. The target
-      Image should be stored in an Images type in the file.
+    doc: Link to an internally stored image representing the training frame. The
+      target Image should be stored in an Images type in the file.
     quantity: '?'
 - neurodata_type_def: SkeletonInstance
   neurodata_type_inc: NWBDataInterface
   default_name: skeleton_instance
-  doc: Group that holds ground-truth pose data for a single instance of a skeleton
-    in a single frame.
+  doc: Group that holds ground-truth pose data for a single instance of a
+    skeleton in a single frame.
   attributes:
   - name: id
     dtype: uint8
@@ -202,15 +208,16 @@ groups:
       - 2
     - - null
       - 3
-    doc: Locations (x, y) or (x, y, z) of nodes for single instance in single frame.
+    doc: Locations (x, y) or (x, y, z) of nodes for single instance in single
+      frame.
   - name: node_visibility
     dtype: bool
     dims:
     - num_body_parts
     shape:
     - null
-    doc: Markers for node visibility where true corresponds to a visible node and
-      false corresponds to an occluded node.
+    doc: Markers for node visibility where true corresponds to a visible node
+      and false corresponds to an occluded node.
     quantity: '?'
   links:
   - target_type: Skeleton
@@ -221,17 +228,18 @@ groups:
   doc: Organizational group to hold training frames.
   groups:
   - neurodata_type_inc: TrainingFrame
-    doc: Ground-truth position data for all instances of a skeleton in a single frame.
+    doc: Ground-truth position data for all instances of a skeleton in a single
+      frame.
     quantity: '*'
 - neurodata_type_def: SkeletonInstances
   neurodata_type_inc: NWBDataInterface
   default_name: skeleton_instances
-  doc: Organizational group to hold skeleton instances. This is meant to be used within
-    a TrainingFrame.
+  doc: Organizational group to hold skeleton instances. This is meant to be used
+    within a TrainingFrame.
   groups:
   - neurodata_type_inc: SkeletonInstance
-    doc: Ground-truth position data for a single instance of a skeleton in a single
-      training frame.
+    doc: Ground-truth position data for a single instance of a skeleton in a
+      single training frame.
     quantity: '*'
 - neurodata_type_def: SourceVideos
   neurodata_type_inc: NWBDataInterface
@@ -247,13 +255,14 @@ groups:
   doc: Organizational group to hold skeletons.
   groups:
   - neurodata_type_inc: Skeleton
-    doc: Skeleton used in project where each skeleton corresponds to a unique morphology.
+    doc: Skeleton used in project where each skeleton corresponds to a unique
+      morphology.
     quantity: '*'
 - neurodata_type_def: PoseTraining
   neurodata_type_inc: NWBDataInterface
   default_name: PoseTraining
-  doc: Group that holds source videos and ground-truth annotations for training a
-    pose estimator.
+  doc: Group that holds source videos and ground-truth annotations for training
+    a pose estimator.
   groups:
   - name: training_frames
     neurodata_type_inc: TrainingFrames

--- a/spec/ndx-pose.namespace.yaml
+++ b/spec/ndx-pose.namespace.yaml
@@ -22,4 +22,4 @@ namespaces:
   schema:
   - namespace: core
   - source: ndx-pose.extensions.yaml
-  version: 0.2.1
+  version: 0.3.0

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -16,7 +16,7 @@ def main():
     ns_builder = NWBNamespaceBuilder(
         doc="NWB extension to store pose estimation data",
         name="ndx-pose",
-        version="0.2.1",
+        version="0.3.0",
         author=[
             "Ryan Ly",
             "Ben Dichter",


### PR DESCRIPTION
## Summary

Prepares the 0.3.0 release, regenerates the extension spec YAML with the latest `ruamel.yaml`, and documents the development install.

### Release 0.3.0
- Bump version to `0.3.0` in `pyproject.toml` and `docs/source/conf.py`.
- Bump the extension namespace version from `0.2.1` to `0.3.0` (in `spec/ndx-pose.namespace.yaml` and `src/spec/create_extension_spec.py`) to match the schema changes introduced this cycle (the optional `source_video` and `labeled_video` links on `PoseEstimation`).
- Convert the CHANGELOG `Upcoming` section to a dated `0.3.0 (June 2, 2026)` release.

### Regenerate spec YAML
- Regenerate `spec/ndx-pose.extensions.yaml` with `ruamel.yaml` 0.19.1. Only the docstring line wrapping changed; the schema content is unchanged.
- Strip the trailing whitespace `ruamel.yaml` leaves on wrapped lines.

### Document development installation
- Add a "Development installation" subsection to the README describing the editable install with the PEP 735 dev dependency group (`pip install -e . --group dev`).

## Testing

Validated in a fresh conda env (Python 3.13):

- `pip install -e . --group dev`: succeeds (the command documented in the README).
- `pytest`: 31 passed, 277 subtests passed, no warnings.
- `ruff check .`: all checks passed.
- `make html` in `docs/`: build succeeded with no warnings or errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)