### PR TITLE
Set `num_samples` on external ImageSeries for pynwb 4.0 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## ndx-pose 0.3.1 (upcoming)
 
+### Minor updates
+- Bumped the minimum supported `pynwb` to 4.0.0 (and `hdmf` to 6.1.0). `num_samples` on `ImageSeries` and the
+  requirement to set it for external, rate-timed videos are only available in pynwb 4.0. @rly
+
 ### Bug fixes
 - Set `num_samples` on the external `ImageSeries` objects used in the mocks, tests, and examples. pynwb 4.0
   requires `num_samples` when `format='external'` and timing is specified with `rate`, because the empty data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
   requires `num_samples` when `format='external'` and timing is specified with `rate`, because the empty data
   array cannot be used to infer the number of frames. @rly (#62)
 
-
+## ndx-pose 0.3.0 (June 2, 2026)
 
 ### Schema changes
 - Added optional `source_video` and `labeled_video` links on `PoseEstimation` that reference an `ImageSeries`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog for ndx-pose
 
-## ndx-pose 0.3.0 (June 2, 2026)
+## ndx-pose 0.3.1 (upcoming)
+
+### Bug fixes
+- Set `num_samples` on the external `ImageSeries` objects used in the mocks, tests, and examples. pynwb 4.0
+  requires `num_samples` when `format='external'` and timing is specified with `rate`, because the empty data
+  array cannot be used to infer the number of frames. @rly
+
+
 
 ### Schema changes
 - Added optional `source_video` and `labeled_video` links on `PoseEstimation` that reference an `ImageSeries`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@
 
 ### Minor updates
 - Bumped the minimum supported `pynwb` to 4.0.0 (and `hdmf` to 6.1.0). `num_samples` on `ImageSeries` and the
-  requirement to set it for external, rate-timed videos are only available in pynwb 4.0. @rly
+  requirement to set it for external, rate-timed videos are only available in pynwb 4.0. @rly (#62)
 
 ### Bug fixes
 - Set `num_samples` on the external `ImageSeries` objects used in the mocks, tests, and examples. pynwb 4.0
   requires `num_samples` when `format='external'` and timing is specified with `rate`, because the empty data
-  array cannot be used to infer the number of frames. @rly
+  array cannot be used to infer the number of frames. @rly (#62)
 
 
 

--- a/examples/write_pose_estimates_only.py
+++ b/examples/write_pose_estimates_only.py
@@ -61,6 +61,7 @@ source_video = ImageSeries(
     dimension=[640, 480],
     starting_frame=[0],
     rate=30.0,
+    num_samples=100,
 )
 labeled_video = ImageSeries(
     name="labeled_video",
@@ -71,6 +72,7 @@ labeled_video = ImageSeries(
     dimension=[640, 480],
     starting_frame=[0],
     rate=30.0,
+    num_samples=100,
 )
 nwbfile.add_acquisition(source_video)
 nwbfile.add_acquisition(labeled_video)

--- a/examples/write_pose_training.py
+++ b/examples/write_pose_training.py
@@ -69,6 +69,7 @@ training_video1 = ImageSeries(
     dimension=[640, 480],
     starting_frame=[0],
     rate=30.0,
+    num_samples=500,
 )
 
 # initial locations ((x, y) coordinates) of each node in the skeleton.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,8 @@ keywords = [
     'ndx-extension',
 ]
 dependencies = [
-    "pynwb>=2.6.0",
-    "hdmf>=3.13.0",
+    "pynwb>=4.0.0",
+    "hdmf>=6.1.0",
 ]
 
 # Dependency groups (PEP 735) - for development, not published to PyPI
@@ -65,9 +65,9 @@ dev = [
 ]
 # minimum requirements of project dependencies for testing on Python 3.10 (see .github/workflows/run_all_tests.yml)
 min-reqs = [
-    "pynwb==2.6.0; python_version == '3.10'",
-    "hdmf==3.13.0; python_version == '3.10'",
-    "numpy<2; python_version == '3.10'",
+    "pynwb==4.0.0; python_version == '3.10'",
+    "hdmf==6.1.0; python_version == '3.10'",
+    "numpy==1.24.0; python_version == '3.10'",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ dev = [
 min-reqs = [
     "pynwb==4.0.0; python_version == '3.10'",
     "hdmf==6.1.0; python_version == '3.10'",
-    "numpy==1.24.0; python_version == '3.10'",
 ]
 
 [project.urls]

--- a/src/pynwb/ndx_pose/testing/mock/pose.py
+++ b/src/pynwb/ndx_pose/testing/mock/pose.py
@@ -189,6 +189,7 @@ def mock_source_video(
         dimension=[640, 480],
         starting_frame=[0],
         rate=30.0,
+        num_samples=100,
     )
     return source_video
 

--- a/src/pynwb/tests/integration/hdf5/test_pose.py
+++ b/src/pynwb/tests/integration/hdf5/test_pose.py
@@ -216,6 +216,7 @@ class TestPoseEstimationRoundtripSourceVideo(TestCase):
             dimension=[640, 480],
             starting_frame=[0],
             rate=30.0,
+            num_samples=10,
         )
         self.nwbfile.add_acquisition(source_video)
 
@@ -276,6 +277,7 @@ class TestPoseEstimationRoundtripLabeledVideo(TestCase):
             dimension=[640, 480],
             starting_frame=[0],
             rate=30.0,
+            num_samples=10,
         )
         self.nwbfile.add_acquisition(labeled_video)
 

--- a/src/pynwb/tests/unit/test_pose.py
+++ b/src/pynwb/tests/unit/test_pose.py
@@ -240,6 +240,7 @@ class TestPoseEstimationConstructor(TestCase):
             dimension=[640, 480],
             starting_frame=[0],
             rate=30.0,
+            num_samples=10,
         )
         skeleton = mock_Skeleton()
         pose_estimation_series = [mock_PoseEstimationSeries(name=name) for name in skeleton.nodes]
@@ -279,6 +280,7 @@ class TestPoseEstimationConstructor(TestCase):
             dimension=[640, 480],
             starting_frame=[0],
             rate=30.0,
+            num_samples=10,
         )
         skeleton = mock_Skeleton()
         pose_estimation_series = [mock_PoseEstimationSeries(name=name) for name in skeleton.nodes]


### PR DESCRIPTION
## Motivation

pynwb 4.0 raises a `ValueError` when constructing an `ImageSeries` with `format='external'` and timing specified via `rate` unless `num_samples` is set, because the empty `data` array can no longer be used to infer the number of frames. This breaks the ndx-pose mocks, tests, and examples on pynwb 4.0.

`num_samples` on `ImageSeries` does not exist before pynwb 4.0 (verified absent in 2.6.0/2.7.0/2.8.3/3.0.0), so this also raises the minimum supported pynwb.

## Changes

- Raise the minimum supported `pynwb` to `4.0.0` and `hdmf` to `6.1.0`, and bump the min-reqs test floor to match.
- Drop the `numpy` pin from min-reqs. numpy is not a direct dependency of ndx-pose; the old `numpy<2` pin capped the previous pynwb 2.6 / hdmf 3.13 stack (which did not support numpy 2.x). numpy now resolves transitively from the pynwb/hdmf requirements.
- Set `num_samples` on every external `ImageSeries` constructed in:
  - `src/pynwb/ndx_pose/testing/mock/pose.py` (`mock_source_video`)
  - `src/pynwb/tests/unit/test_pose.py` (source/labeled video constructor tests)
  - `src/pynwb/tests/integration/hdf5/test_pose.py` (source/labeled video roundtrip tests)
  - `examples/write_pose_estimates_only.py`
  - `examples/write_pose_training.py`

  The chosen `num_samples` values cover the referenced frame indices (e.g. 500 for the training example, which references frame indices up to 495).

## Testing

`pytest src/pynwb/tests` passes (31 passed, 279 subtests) against:
- Latest release: pynwb 4.0.0 / hdmf 6.1.0 / numpy 2.5.1.
- The min-reqs floor on Python 3.10: pynwb==4.0.0 / hdmf==6.1.0, with numpy resolved to 2.2.6.

Also verified with `ruff check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)