### PR TITLE
Raise when `source_software_version` is set without `source_software`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Set `num_samples` on the external `ImageSeries` objects used in the mocks, tests, and examples. pynwb 4.0
   requires `num_samples` when `format='external'` and timing is specified with `rate`, because the empty data
   array cannot be used to infer the number of frames. @rly (#62)
+- `PoseEstimation` now raises when `source_software_version` is set without `source_software`. The version is
+  stored as an attribute on the `source_software` dataset, so it was previously dropped silently on roundtrip.
+  @h-mayorquin (#63)
 
 ## ndx-pose 0.3.0 (June 2, 2026)
 

--- a/src/pynwb/ndx_pose/pose.py
+++ b/src/pynwb/ndx_pose/pose.py
@@ -319,6 +319,11 @@ class PoseEstimation(MultiContainerInterface):
         pose_estimation_series, description = popargs("pose_estimation_series", "description", kwargs)
         scorer = popargs("scorer", kwargs)
         source_software, source_software_version = popargs("source_software", "source_software_version", kwargs)
+        if source_software_version is not None and source_software is None:
+            raise ValueError(
+                "'source_software_version' was specified without 'source_software'. The version is stored as an "
+                "attribute on the 'source_software' dataset, so 'source_software' must be provided as well."
+            )
         super().__init__(**kwargs)
 
         self.pose_estimation_series = pose_estimation_series

--- a/src/pynwb/tests/unit/test_pose.py
+++ b/src/pynwb/tests/unit/test_pose.py
@@ -182,6 +182,27 @@ class TestPoseEstimationConstructor(TestCase):
                 skeleton=skeleton,
             )
 
+    def test_source_software_version_without_source_software_raises(self):
+        """Test that setting source_software_version without source_software raises.
+
+        source_software_version is stored as the 'version' attribute on the 'source_software'
+        dataset, so it cannot be written without source_software and would otherwise be silently
+        dropped on roundtrip.
+        """
+        skeleton = mock_Skeleton()
+        pose_estimation_series = [mock_PoseEstimationSeries(name=name) for name in skeleton.nodes]
+
+        msg = (
+            "'source_software_version' was specified without 'source_software'. The version is stored as an "
+            "attribute on the 'source_software' dataset, so 'source_software' must be provided as well."
+        )
+        with self.assertRaisesWith(ValueError, msg):
+            PoseEstimation(
+                pose_estimation_series=pose_estimation_series,
+                skeleton=skeleton,
+                source_software_version="2.2b8",
+            )
+
     def test_constructor_nodes_edges(self):
         """Test the old constructor for PoseEstimation with nodes and edges."""
         front_left_paw = mock_PoseEstimationSeries(


### PR DESCRIPTION
`PoseEstimation` stores `source_software_version` as the `version` attribute on the `source_software` dataset. When the version was passed without the software name, there was no dataset for the attribute to attach to, so the value was accepted at construction and then silently dropped on write, with no warning and no error. Nothing about the storage layout changes here and no capability is removed: version plus software name has always round-tripped correctly and still does. This just turns the impossible case into a `ValueError` at construction time instead of a quiet data loss at write time.

I scoped this to `PoseEstimation` because that is the only affected type on `main`. `MultiCameraPoseEstimation` (currently in #57) has the same attribute-on-dataset layout and the same flaw; I would rather let that branch pick up an equivalent guard once it merges than widen this PR across branches.