### PR TITLE
Regenerate the spec YAML from create_extension_spec.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@
 - `ndx_pose.testing.mock.mock_PoseEstimation` defaults `original_videos`, `labeled_videos`, and `dimensions`
   to `None` instead of sample values, so the mock no longer triggers the deprecation warnings for those three
   arguments. Pass them explicitly to exercise the deprecated fields. @alessandratrapani (#57)
+- `src/spec/create_extension_spec.py` defines `CalibratedCamera` and `MultiCameraPoseEstimation` and the
+  updated `PoseEstimation`, and the YAML in `spec/` is regenerated from it. The regenerated
+  `CalibratedCamera.intrinsic_matrix` and `CalibratedCamera.rotation_matrix` carry the placeholder dimension
+  names `dim_0` and `dim_1` that hdmf assigns to a dataset declared with a shape and no dimension names.
+  @rly (#64)
 
 ### Bug fixes
 - Set `num_samples` on the external `ImageSeries` objects used in the mocks, tests, and examples. pynwb 4.0

--- a/spec/ndx-pose.extensions.yaml
+++ b/spec/ndx-pose.extensions.yaml
@@ -1,398 +1,380 @@
 groups:
-  - neurodata_type_def: Skeleton
-    neurodata_type_inc: NWBDataInterface
-    doc: Group that holds node and edge data for defining parts of a pose and
-      their connections to one another. Names should be unique in a file.
-    datasets:
-      - name: nodes
-        dtype: text
-        dims:
-          - num_body_parts
-        shape:
-          - null
-        doc: Array of body part names corresponding to the names of the
-          PoseEstimationSeries objects or PoseTraining objects.
-      - name: edges
-        dtype: uint8
-        dims:
-          - num_edges
-          - nodes_index, nodes_index
-        shape:
-          - null
-          - 2
-        doc:
-          Array of pairs of indices corresponding to edges between nodes. Index
-          values correspond to row indices of the 'nodes' dataset. Index values use
-          0-indexing.
-        quantity: "?"
-    links:
-      - target_type: Subject
-        doc:
-          The Subject object in the NWB file, if this Skeleton corresponds to the
-          Subject.
-        quantity: "?"
-  - neurodata_type_def: PoseEstimationSeries
-    neurodata_type_inc: SpatialSeries
-    doc: Estimated position (x, y) or (x, y, z) of a body part over time.
-    datasets:
-      - name: data
-        dtype: float32
-        dims:
-          - - num_frames
-            - x, y
-          - - num_frames
-            - x, y, z
-        shape:
-          - - null
-            - 2
-          - - null
-            - 3
-        doc: Estimated position (x, y) or (x, y, z).
-        attributes:
-          - name: unit
-            dtype: text
-            default_value: pixels
-            doc:
-              Base unit of measurement for working with the data. The default value
-              is 'pixels'. Actual stored values are not necessarily stored in these
-              units. To access the data in these units, multiply 'data' by
-              'conversion'.
-            required: false
-      - name: confidence
-        dtype: float32
-        dims:
-          - num_frames
-        shape:
-          - null
-        doc: Confidence or likelihood of the estimated positions, scaled to be
-          between 0 and 1.
-        attributes:
-          - name: definition
-            dtype: text
-            doc:
-              Description of how the confidence was computed, e.g., 'Softmax output
-              of the deep neural network'.
-            required: false
-  - neurodata_type_def: PoseEstimation
-    neurodata_type_inc: NWBDataInterface
-    default_name: PoseEstimation
-    doc: Group that holds estimated position data for multiple body parts,
-      computed from a single camera view with the same tool/algorithm. The timestamps of
-      each child PoseEstimationSeries type should be the same. To store pose estimates
-      from multiple synchronized cameras (e.g., triangulated 3D estimates), use a
-      MultiCameraPoseEstimation object, which holds one PoseEstimation child per camera
-      view alongside the shared 3D estimates.
-    datasets:
-      - name: description
-        dtype: text
-        doc: Description of the pose estimation procedure and output.
-        quantity: "?"
-      - name: original_videos
-        dtype: text
-        dims:
-          - num_files
-        shape:
-          - null
-        doc:
-          DEPRECATED. Please use the 'source_video' link instead.
-          Paths to the original video files. Note that these string paths might be fragile
-          unless relative paths are used and care is taken to keep them consistent.
-        quantity: "?"
-      - name: labeled_videos
-        dtype: text
-        dims:
-          - num_files
-        shape:
-          - null
-        doc:
-          DEPRECATED. Please use the 'labeled_video' link instead.
-          Paths to the labeled video files. Note that these string paths might be fragile
-          unless relative paths are used and care is taken to keep them consistent.
-        quantity: "?"
-      - name: dimensions
-        dtype: uint8
-        dims:
-          - num_files
-          - width, height
-        shape:
-          - null
-          - 2
-        doc:
-          DEPRECATED. Please use the 'dimension' field of the ImageSeries linked as
-          'source_video' or 'labeled_video' instead.
-          Dimensions of each labeled video file.
-        quantity: "?"
-      - name: scorer
-        dtype: text
-        doc: Name of the scorer / algorithm used.
-        quantity: "?"
-      - name: source_software
-        dtype: text
-        doc: Name of the software tool used. Specifying the version attribute is
-          strongly encouraged.
-        quantity: "?"
-        attributes:
-          - name: version
-            dtype: text
-            doc: Version string of the software tool used.
-            required: false
-    groups:
-      - neurodata_type_inc: PoseEstimationSeries
-        doc: Estimated position data for each body part.
-        quantity: "*"
-    links:
-      - target_type: Skeleton
-        doc: Layout of body part locations and connections.
-        quantity: "?"
-      - name: device
-        target_type: Device
-        doc:
-          The camera device used to record the video for this pose estimation. Must be added to the
-          NWBFile before being linked here. Use a CalibratedCamera instead of a plain Device when
-          intrinsic/extrinsic calibration coordinates are available, e.g., for multi-camera 3D pose
-          estimation, where a PoseEstimation object represents a single camera view within a
-          MultiCameraPoseEstimation object.
-        quantity: "?"
-      - name: source_video
-        target_type: ImageSeries
-        doc: Link to an ImageSeries containing the source video used for pose
-          estimation. The ImageSeries should be stored in the NWBFile (e.g., in
-          acquisition). It holds the video data, or the path to an external video
-          file, along with the dimensions and frame timing of the video.
-        quantity: "?"
-      - name: labeled_video
-        target_type: ImageSeries
-        doc: Link to an ImageSeries containing the labeled video (with pose
-          estimation overlays) produced from the source video. The ImageSeries
-          should be stored in the NWBFile (e.g., in acquisition). It holds the video
-          data, or the path to an external video file, along with the dimensions and
-          frame timing of the video.
-        quantity: "?"
-  - neurodata_type_def: TrainingFrame
-    neurodata_type_inc: NWBDataInterface
-    default_name: TrainingFrame
-    doc: Group that holds ground-truth position data for all instances of a
-      skeleton in a single frame.
+- neurodata_type_def: Skeleton
+  neurodata_type_inc: NWBDataInterface
+  doc: Group that holds node and edge data for defining parts of a pose and
+    their connections to one another. Names should be unique in a file.
+  datasets:
+  - name: nodes
+    dtype: text
+    dims:
+    - num_body_parts
+    shape:
+    - null
+    doc: Array of body part names corresponding to the names of the
+      PoseEstimationSeries objects or PoseTraining objects.
+  - name: edges
+    dtype: uint8
+    dims:
+    - num_edges
+    - nodes_index, nodes_index
+    shape:
+    - null
+    - 2
+    doc: Array of pairs of indices corresponding to edges between nodes. Index
+      values correspond to row indices of the 'nodes' dataset. Index values use
+      0-indexing.
+    quantity: '?'
+  links:
+  - target_type: Subject
+    doc: The Subject object in the NWB file, if this Skeleton corresponds to the
+      Subject.
+    quantity: '?'
+- neurodata_type_def: PoseEstimationSeries
+  neurodata_type_inc: SpatialSeries
+  doc: Estimated position (x, y) or (x, y, z) of a body part over time.
+  datasets:
+  - name: data
+    dtype: float32
+    dims:
+    - - num_frames
+      - x, y
+    - - num_frames
+      - x, y, z
+    shape:
+    - - null
+      - 2
+    - - null
+      - 3
+    doc: Estimated position (x, y) or (x, y, z).
     attributes:
-      - name: annotator
-        dtype: text
-        doc: Name of annotator who labeled the TrainingFrame.
-        required: false
-      - name: source_video_frame_index
-        dtype: uint8
-        doc:
-          Frame index of training frame in the original video `source_video`. If
-          provided, then `source_video` is required.
-        required: false
-    groups:
-      - name: skeleton_instances
-        neurodata_type_inc: SkeletonInstances
-        doc: Position data for all instances of a skeleton in a single training
-          frame.
-    links:
-      - name: source_video
-        target_type: ImageSeries
-        doc:
-          Link to an ImageSeries representing a video of training frames (stored
-          internally or externally). Required if `source_video_frame_index` is
-          provided.
-        quantity: "?"
-      - name: source_frame
-        target_type: Image
-        doc:
-          Link to an internally stored image representing the training frame. The
-          target Image should be stored in an Images type in the file.
-        quantity: "?"
-  - neurodata_type_def: SkeletonInstance
-    neurodata_type_inc: NWBDataInterface
-    default_name: skeleton_instance
-    doc: Group that holds ground-truth pose data for a single instance of a
-      skeleton in a single frame.
+    - name: unit
+      dtype: text
+      default_value: pixels
+      doc: Base unit of measurement for working with the data. The default value
+        is 'pixels'. Actual stored values are not necessarily stored in these
+        units. To access the data in these units, multiply 'data' by
+        'conversion'.
+      required: false
+  - name: confidence
+    dtype: float32
+    dims:
+    - num_frames
+    shape:
+    - null
+    doc: Confidence or likelihood of the estimated positions, scaled to be
+      between 0 and 1.
     attributes:
-      - name: id
-        dtype: uint8
-        doc: ID used to differentiate skeleton instances.
-        required: false
-    datasets:
-      - name: node_locations
-        dtype: float
-        dims:
-          - - num_body_parts
-            - x, y
-          - - num_body_parts
-            - x, y, z
-        shape:
-          - - null
-            - 2
-          - - null
-            - 3
-        doc:
-          Locations (x, y) or (x, y, z) of nodes for single instance in single
-          frame.
-      - name: node_visibility
-        dtype: bool
-        dims:
-          - num_body_parts
-        shape:
-          - null
-        doc:
-          Markers for node visibility where true corresponds to a visible node
-          and false corresponds to an occluded node.
-        quantity: "?"
-    links:
-      - target_type: Skeleton
-        doc: Layout of body part locations and connections.
-  - neurodata_type_def: TrainingFrames
-    neurodata_type_inc: NWBDataInterface
-    default_name: training_frames
+    - name: definition
+      dtype: text
+      doc: Description of how the confidence was computed, e.g., 'Softmax output
+        of the deep neural network'.
+      required: false
+- neurodata_type_def: PoseEstimation
+  neurodata_type_inc: NWBDataInterface
+  default_name: PoseEstimation
+  doc: Group that holds estimated position data for multiple body parts,
+    computed from a single camera view with the same tool/algorithm. The
+    timestamps of each child PoseEstimationSeries type should be the same. To
+    store pose estimates from multiple synchronized cameras (e.g., triangulated
+    3D estimates), use a MultiCameraPoseEstimation object, which holds one
+    PoseEstimation child per camera view alongside the shared 3D estimates.
+  datasets:
+  - name: description
+    dtype: text
+    doc: Description of the pose estimation procedure and output.
+    quantity: '?'
+  - name: original_videos
+    dtype: text
+    dims:
+    - num_files
+    shape:
+    - null
+    doc: DEPRECATED. Please use the 'source_video' link instead. Paths to the
+      original video files. Note that these string paths might be fragile unless
+      relative paths are used and care is taken to keep them consistent.
+    quantity: '?'
+  - name: labeled_videos
+    dtype: text
+    dims:
+    - num_files
+    shape:
+    - null
+    doc: DEPRECATED. Please use the 'labeled_video' link instead. Paths to the
+      labeled video files. Note that these string paths might be fragile unless
+      relative paths are used and care is taken to keep them consistent.
+    quantity: '?'
+  - name: dimensions
+    dtype: uint8
+    dims:
+    - num_files
+    - width, height
+    shape:
+    - null
+    - 2
+    doc: DEPRECATED. Please use the 'dimension' field of the ImageSeries linked
+      as 'source_video' or 'labeled_video' instead. Dimensions of each labeled
+      video file.
+    quantity: '?'
+  - name: scorer
+    dtype: text
+    doc: Name of the scorer / algorithm used.
+    quantity: '?'
+  - name: source_software
+    dtype: text
+    doc: Name of the software tool used. Specifying the version attribute is
+      strongly encouraged.
+    quantity: '?'
+    attributes:
+    - name: version
+      dtype: text
+      doc: Version string of the software tool used.
+      required: false
+  groups:
+  - neurodata_type_inc: PoseEstimationSeries
+    doc: Estimated position data for each body part.
+    quantity: '*'
+  links:
+  - target_type: Skeleton
+    doc: Layout of body part locations and connections.
+    quantity: '?'
+  - name: device
+    target_type: Device
+    doc: The camera device used to record the video for this pose estimation.
+      Must be added to the NWBFile before being linked here. Use a
+      CalibratedCamera instead of a plain Device when intrinsic/extrinsic
+      calibration coordinates are available, e.g., for multi-camera 3D pose
+      estimation, where a PoseEstimation object represents a single camera view
+      within a MultiCameraPoseEstimation object.
+    quantity: '?'
+  - name: source_video
+    target_type: ImageSeries
+    doc: Link to an ImageSeries containing the source video used for pose
+      estimation. The ImageSeries should be stored in the NWBFile (e.g., in
+      acquisition). It holds the video data, or the path to an external video
+      file, along with the dimensions and frame timing of the video.
+    quantity: '?'
+  - name: labeled_video
+    target_type: ImageSeries
+    doc: Link to an ImageSeries containing the labeled video (with pose
+      estimation overlays) produced from the source video. The ImageSeries
+      should be stored in the NWBFile (e.g., in acquisition). It holds the video
+      data, or the path to an external video file, along with the dimensions and
+      frame timing of the video.
+    quantity: '?'
+- neurodata_type_def: TrainingFrame
+  neurodata_type_inc: NWBDataInterface
+  default_name: TrainingFrame
+  doc: Group that holds ground-truth position data for all instances of a
+    skeleton in a single frame.
+  attributes:
+  - name: annotator
+    dtype: text
+    doc: Name of annotator who labeled the TrainingFrame.
+    required: false
+  - name: source_video_frame_index
+    dtype: uint8
+    doc: Frame index of training frame in the original video `source_video`. If
+      provided, then `source_video` is required.
+    required: false
+  groups:
+  - name: skeleton_instances
+    neurodata_type_inc: SkeletonInstances
+    doc: Position data for all instances of a skeleton in a single training
+      frame.
+  links:
+  - name: source_video
+    target_type: ImageSeries
+    doc: Link to an ImageSeries representing a video of training frames (stored
+      internally or externally). Required if `source_video_frame_index` is
+      provided.
+    quantity: '?'
+  - name: source_frame
+    target_type: Image
+    doc: Link to an internally stored image representing the training frame. The
+      target Image should be stored in an Images type in the file.
+    quantity: '?'
+- neurodata_type_def: SkeletonInstance
+  neurodata_type_inc: NWBDataInterface
+  default_name: skeleton_instance
+  doc: Group that holds ground-truth pose data for a single instance of a
+    skeleton in a single frame.
+  attributes:
+  - name: id
+    dtype: uint8
+    doc: ID used to differentiate skeleton instances.
+    required: false
+  datasets:
+  - name: node_locations
+    dtype: float
+    dims:
+    - - num_body_parts
+      - x, y
+    - - num_body_parts
+      - x, y, z
+    shape:
+    - - null
+      - 2
+    - - null
+      - 3
+    doc: Locations (x, y) or (x, y, z) of nodes for single instance in single
+      frame.
+  - name: node_visibility
+    dtype: bool
+    dims:
+    - num_body_parts
+    shape:
+    - null
+    doc: Markers for node visibility where true corresponds to a visible node
+      and false corresponds to an occluded node.
+    quantity: '?'
+  links:
+  - target_type: Skeleton
+    doc: Layout of body part locations and connections.
+- neurodata_type_def: TrainingFrames
+  neurodata_type_inc: NWBDataInterface
+  default_name: training_frames
+  doc: Organizational group to hold training frames.
+  groups:
+  - neurodata_type_inc: TrainingFrame
+    doc: Ground-truth position data for all instances of a skeleton in a single
+      frame.
+    quantity: '*'
+- neurodata_type_def: SkeletonInstances
+  neurodata_type_inc: NWBDataInterface
+  default_name: skeleton_instances
+  doc: Organizational group to hold skeleton instances. This is meant to be used
+    within a TrainingFrame.
+  groups:
+  - neurodata_type_inc: SkeletonInstance
+    doc: Ground-truth position data for a single instance of a skeleton in a
+      single training frame.
+    quantity: '*'
+- neurodata_type_def: SourceVideos
+  neurodata_type_inc: NWBDataInterface
+  default_name: source_videos
+  doc: Organizational group to hold source videos used for training.
+  groups:
+  - neurodata_type_inc: ImageSeries
+    doc: Video of training frames (stored internally or externally
+    quantity: '*'
+- neurodata_type_def: Skeletons
+  neurodata_type_inc: NWBDataInterface
+  default_name: Skeletons
+  doc: Organizational group to hold skeletons.
+  groups:
+  - neurodata_type_inc: Skeleton
+    doc: Skeleton used in project where each skeleton corresponds to a unique
+      morphology.
+    quantity: '*'
+- neurodata_type_def: PoseTraining
+  neurodata_type_inc: NWBDataInterface
+  default_name: PoseTraining
+  doc: Group that holds source videos and ground-truth annotations for training
+    a pose estimator.
+  groups:
+  - name: training_frames
+    neurodata_type_inc: TrainingFrames
     doc: Organizational group to hold training frames.
-    groups:
-      - neurodata_type_inc: TrainingFrame
-        doc:
-          Ground-truth position data for all instances of a skeleton in a single
-          frame.
-        quantity: "*"
-  - neurodata_type_def: SkeletonInstances
-    neurodata_type_inc: NWBDataInterface
-    default_name: skeleton_instances
-    doc:
-      Organizational group to hold skeleton instances. This is meant to be used
-      within a TrainingFrame.
-    groups:
-      - neurodata_type_inc: SkeletonInstance
-        doc: Ground-truth position data for a single instance of a skeleton in a
-          single training frame.
-        quantity: "*"
-  - neurodata_type_def: SourceVideos
-    neurodata_type_inc: NWBDataInterface
-    default_name: source_videos
+    quantity: '?'
+  - name: source_videos
+    neurodata_type_inc: SourceVideos
     doc: Organizational group to hold source videos used for training.
-    groups:
-      - neurodata_type_inc: ImageSeries
-        doc: Video of training frames (stored internally or externally
-        quantity: "*"
-  - neurodata_type_def: Skeletons
-    neurodata_type_inc: NWBDataInterface
-    default_name: Skeletons
-    doc: Organizational group to hold skeletons.
-    groups:
-      - neurodata_type_inc: Skeleton
-        doc:
-          Skeleton used in project where each skeleton corresponds to a unique
-          morphology.
-        quantity: "*"
-  - neurodata_type_def: PoseTraining
-    neurodata_type_inc: NWBDataInterface
-    default_name: PoseTraining
-    doc:
-      Group that holds source videos and ground-truth annotations for training
-      a pose estimator.
-    groups:
-      - name: training_frames
-        neurodata_type_inc: TrainingFrames
-        doc: Organizational group to hold training frames.
-        quantity: "?"
-      - name: source_videos
-        neurodata_type_inc: SourceVideos
-        doc: Organizational group to hold source videos used for training.
-        quantity: "?"
-  - neurodata_type_def: CalibratedCamera
-    neurodata_type_inc: Device
-    doc:
-      A Device representing a single camera in a multi-camera pose estimation setup,
-      extended with its intrinsic and extrinsic calibration parameters. Link a
-      CalibratedCamera (instead of a plain Device) from a PoseEstimation object
-      wherever calibration coordinates are available. Because it is a Device, it is
-      added once to the NWBFile (e.g., in general/devices) and can be linked to by
-      reference from multiple PoseEstimation objects (e.g., one per subject in a
-      multi-subject recording session), so the camera rig and its calibration are
-      never duplicated.
-    datasets:
-      - name: intrinsic_matrix
-        dtype: float32
-        shape:
-          - 3
-          - 3
-        doc:
-          Intrinsic camera matrix K, encoding focal length and principal point.
-          Shape (3, 3).
-      - name: rotation_matrix
-        dtype: float32
-        shape:
-          - 3
-          - 3
-        doc:
-          Rotation matrix R mapping world coordinates to this camera's coordinate
-          frame. Shape (3, 3).
-        quantity: "?"
-      - name: translation_vector
-        dtype: float32
-        dims:
-          - x, y, z
-        shape:
-          - 3
-        doc:
-          Translation vector t mapping world coordinates to this camera's coordinate
-          frame. Shape (3,).
-        quantity: "?"
-      - name: distortion_coefficients
-        dtype: float32
-        dims:
-          - num_distortion_params
-        shape:
-          - null
-        doc: Lens distortion coefficients for this camera. Length depends on the
-          distortion model (typically 4 or 5 for radial-tangential).
-        quantity: "?"
-  - neurodata_type_def: MultiCameraPoseEstimation
-    neurodata_type_inc: NWBDataInterface
-    default_name: MultiCameraPoseEstimation
-    doc:
-      Group that holds 3D pose estimation data computed from multiple synchronized
-      cameras. Unlike PoseEstimation (single-camera, pixel-space), this type stores
-      keypoints in a shared 3D world-space reference frame and organizes per-camera
-      2D data through PoseEstimation children, one per camera view, each of which
-      links to the camera Device (typically a CalibratedCamera, so that calibration
-      travels with the camera rather than being duplicated here). Designed for
-      systems such as DANNCE or Anipose that triangulate 3D positions from
-      synchronized multi-camera footage.
-    datasets:
-      - name: description
-        dtype: text
-        doc: Description of the pose estimation procedure and output.
-        quantity: "?"
-      - name: scorer
-        dtype: text
-        doc: Name of the scorer / algorithm used.
-        quantity: "?"
-      - name: source_software
-        dtype: text
-        doc:
-          Name of the software tool used. Specifying the version attribute is strongly
-          encouraged.
-        quantity: "?"
-        attributes:
-          - name: version
-            dtype: text
-            doc: Version string of the software tool used.
-            required: false
-    groups:
-      - neurodata_type_inc: PoseEstimationSeries
-        doc:
-          Estimated 3D position (x, y, z) of each body part in a shared world-space
-          coordinate frame. The unit should be a physical length unit (e.g. 'meters'
-          or 'millimeters'), not 'pixels'.
-        quantity: "*"
-      - neurodata_type_inc: PoseEstimation
-        doc:
-          Per-camera 2D pose estimates, one PoseEstimation per camera view. Each
-          PoseEstimation links to the camera Device (ideally a CalibratedCamera)
-          used to record that view and, optionally, to that view's source video and
-          2D pose estimates in pixel space.
-        quantity: "*"
-    links:
-      - target_type: Skeleton
-        doc:
-          Layout of body part locations and connections. The Skeleton object should
-          be placed in a Skeletons object at the same level as this container.
-        quantity: "?"
+    quantity: '?'
+- neurodata_type_def: CalibratedCamera
+  neurodata_type_inc: Device
+  doc: A Device representing a single camera in a multi-camera pose estimation
+    setup, extended with its intrinsic and extrinsic calibration parameters.
+    Link a CalibratedCamera (instead of a plain Device) from a PoseEstimation
+    object wherever calibration coordinates are available. Because it is a
+    Device, it is added once to the NWBFile (e.g., in general/devices) and can
+    be linked to by reference from multiple PoseEstimation objects (e.g., one
+    per subject in a multi-subject recording session), so the camera rig and its
+    calibration are never duplicated.
+  datasets:
+  - name: intrinsic_matrix
+    dtype: float32
+    dims:
+    - dim_0
+    - dim_1
+    shape:
+    - 3
+    - 3
+    doc: Intrinsic camera matrix K, encoding focal length and principal point.
+      Shape (3, 3).
+  - name: rotation_matrix
+    dtype: float32
+    dims:
+    - dim_0
+    - dim_1
+    shape:
+    - 3
+    - 3
+    doc: Rotation matrix R mapping world coordinates to this camera's coordinate
+      frame. Shape (3, 3).
+    quantity: '?'
+  - name: translation_vector
+    dtype: float32
+    dims:
+    - x, y, z
+    shape:
+    - 3
+    doc: Translation vector t mapping world coordinates to this camera's
+      coordinate frame. Shape (3,).
+    quantity: '?'
+  - name: distortion_coefficients
+    dtype: float32
+    dims:
+    - num_distortion_params
+    shape:
+    - null
+    doc: Lens distortion coefficients for this camera. Length depends on the
+      distortion model (typically 4 or 5 for radial-tangential).
+    quantity: '?'
+- neurodata_type_def: MultiCameraPoseEstimation
+  neurodata_type_inc: NWBDataInterface
+  default_name: MultiCameraPoseEstimation
+  doc: Group that holds 3D pose estimation data computed from multiple
+    synchronized cameras. Unlike PoseEstimation (single-camera, pixel-space),
+    this type stores keypoints in a shared 3D world-space reference frame and
+    organizes per-camera 2D data through PoseEstimation children, one per camera
+    view, each of which links to the camera Device (typically a
+    CalibratedCamera, so that calibration travels with the camera rather than
+    being duplicated here). Designed for systems such as DANNCE or Anipose that
+    triangulate 3D positions from synchronized multi-camera footage.
+  datasets:
+  - name: description
+    dtype: text
+    doc: Description of the pose estimation procedure and output.
+    quantity: '?'
+  - name: scorer
+    dtype: text
+    doc: Name of the scorer / algorithm used.
+    quantity: '?'
+  - name: source_software
+    dtype: text
+    doc: Name of the software tool used. Specifying the version attribute is
+      strongly encouraged.
+    quantity: '?'
+    attributes:
+    - name: version
+      dtype: text
+      doc: Version string of the software tool used.
+      required: false
+  groups:
+  - neurodata_type_inc: PoseEstimationSeries
+    doc: Estimated 3D position (x, y, z) of each body part in a shared
+      world-space coordinate frame. The unit should be a physical length unit
+      (e.g. 'meters' or 'millimeters'), not 'pixels'.
+    quantity: '*'
+  - neurodata_type_inc: PoseEstimation
+    doc: Per-camera 2D pose estimates, one PoseEstimation per camera view. Each
+      PoseEstimation links to the camera Device (ideally a CalibratedCamera)
+      used to record that view and, optionally, to that view's source video and
+      2D pose estimates in pixel space.
+    quantity: '*'
+  links:
+  - target_type: Skeleton
+    doc: Layout of body part locations and connections. The Skeleton object
+      should be placed in a Skeletons object at the same level as this
+      container.
+    quantity: '?'

--- a/spec/ndx-pose.namespace.yaml
+++ b/spec/ndx-pose.namespace.yaml
@@ -1,29 +1,29 @@
 namespaces:
-  - author:
-      - Ryan Ly
-      - Ben Dichter
-      - Alexander Mathis
-      - Liezl Maree
-      - Chris Brozdowski
-      - Heberto Mayorquin
-      - Talmo Pereira
-      - Elizabeth Berrigan
-      - Paul Adkisson
-      - Alessandra Trapani
-    contact:
-      - rly@lbl.gov
-      - bdichter@lbl.gov
-      - alexander.mathis@epfl.ch
-      - lmaree@salk.edu
-      - cbroz@datajoint.com
-      - h.mayorquin@gmail.com
-      - talmo@salk.edu
-      - eberrigan@salk.edu
-      - paul.adkisson@catalystneuro.com
-      - alessandra.trapani@catalystneuro.com
-    doc: NWB extension to store pose estimation data
-    name: ndx-pose
-    schema:
-      - namespace: core
-      - source: ndx-pose.extensions.yaml
-    version: 0.4.0
+- author:
+  - Ryan Ly
+  - Ben Dichter
+  - Alexander Mathis
+  - Liezl Maree
+  - Chris Brozdowski
+  - Heberto Mayorquin
+  - Talmo Pereira
+  - Elizabeth Berrigan
+  - Paul Adkisson
+  - Alessandra Trapani
+  contact:
+  - rly@lbl.gov
+  - bdichter@lbl.gov
+  - alexander.mathis@epfl.ch
+  - lmaree@salk.edu
+  - cbroz@datajoint.com
+  - h.mayorquin@gmail.com
+  - talmo@salk.edu
+  - eberrigan@salk.edu
+  - paul.adkisson@catalystneuro.com
+  - alessandra.trapani@catalystneuro.com
+  doc: NWB extension to store pose estimation data
+  name: ndx-pose
+  schema:
+  - namespace: core
+  - source: ndx-pose.extensions.yaml
+  version: 0.4.0

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -149,8 +149,11 @@ def main():
         neurodata_type_def="PoseEstimation",
         neurodata_type_inc="NWBDataInterface",
         doc=(
-            "Group that holds estimated position data for multiple body parts, computed from the same video with "
-            "the same tool/algorithm. The timestamps of each child PoseEstimationSeries type should be the same."
+            "Group that holds estimated position data for multiple body parts, computed from a single camera view "
+            "with the same tool/algorithm. The timestamps of each child PoseEstimationSeries type should be the "
+            "same. To store pose estimates from multiple synchronized cameras (e.g., triangulated 3D estimates), "
+            "use a MultiCameraPoseEstimation object, which holds one PoseEstimation child per camera view "
+            "alongside the shared 3D estimates."
         ),
         default_name="PoseEstimation",
         groups=[
@@ -167,18 +170,25 @@ def main():
                 quantity="?",
             ),
             NWBLinkSpec(
+                name="device",
                 target_type="Device",
-                doc="Cameras used to record the videos.",
-                quantity="*",
+                doc=(
+                    "The camera device used to record the video for this pose estimation. Must be added to the "
+                    "NWBFile before being linked here. Use a CalibratedCamera instead of a plain Device when "
+                    "intrinsic/extrinsic calibration coordinates are available, e.g., for multi-camera 3D pose "
+                    "estimation, where a PoseEstimation object represents a single camera view within a "
+                    "MultiCameraPoseEstimation object."
+                ),
+                quantity="?",
             ),
             NWBLinkSpec(
                 name="source_video",
                 target_type="ImageSeries",
                 doc=(
                     "Link to an ImageSeries containing the source video used for pose estimation. The "
-                    "ImageSeries should be stored in the NWBFile (e.g., in acquisition). When available, this "
-                    "field should be preferred over 'original_videos' as it provides a formal reference rather "
-                    "than a file path string."
+                    "ImageSeries should be stored in the NWBFile (e.g., in acquisition). It holds the video "
+                    "data, or the path to an external video file, along with the dimensions and frame timing of "
+                    "the video."
                 ),
                 quantity="?",
             ),
@@ -188,8 +198,8 @@ def main():
                 doc=(
                     "Link to an ImageSeries containing the labeled video (with pose estimation overlays) "
                     "produced from the source video. The ImageSeries should be stored in the NWBFile (e.g., in "
-                    "acquisition). When available, this field should be preferred over 'labeled_videos' as it "
-                    "provides a formal reference rather than a file path string."
+                    "acquisition). It holds the video data, or the path to an external video file, along with "
+                    "the dimensions and frame timing of the video."
                 ),
                 quantity="?",
             ),
@@ -204,10 +214,9 @@ def main():
             NWBDatasetSpec(
                 name="original_videos",
                 doc=(
-                    "Paths to the original video files. The number of files should equal the number of camera "
-                    "devices. Note that these string paths might be fragile unless relative paths are used and "
-                    "care is taken to keep them consistent. Consider using the 'source_video' link instead for "
-                    "a formal reference."
+                    "DEPRECATED. Please use the 'source_video' link instead. Paths to the original video files. "
+                    "Note that these string paths might be fragile unless relative paths are used and care is "
+                    "taken to keep them consistent."
                 ),
                 dtype="text",
                 dims=["num_files"],
@@ -217,10 +226,9 @@ def main():
             NWBDatasetSpec(
                 name="labeled_videos",
                 doc=(
-                    "Paths to the labeled video files. The number of files should equal the number of camera "
-                    "devices. Note that these string paths might be fragile unless relative paths are used and "
-                    "care is taken to keep them consistent. Consider using the 'labeled_video' link instead for "
-                    "a formal reference."
+                    "DEPRECATED. Please use the 'labeled_video' link instead. Paths to the labeled video files. "
+                    "Note that these string paths might be fragile unless relative paths are used and care is "
+                    "taken to keep them consistent."
                 ),
                 dtype="text",
                 dims=["num_files"],
@@ -229,7 +237,10 @@ def main():
             ),
             NWBDatasetSpec(
                 name="dimensions",
-                doc="Dimensions of each labeled video file.",
+                doc=(
+                    "DEPRECATED. Please use the 'dimension' field of the ImageSeries linked as 'source_video' "
+                    "or 'labeled_video' instead. Dimensions of each labeled video file."
+                ),
                 dtype="uint8",
                 dims=["num_files", "width, height"],
                 shape=[None, 2],
@@ -418,6 +429,125 @@ def main():
         ],
     )
 
+    calibrated_camera = NWBGroupSpec(
+        neurodata_type_def="CalibratedCamera",
+        neurodata_type_inc="Device",
+        doc=(
+            "A Device representing a single camera in a multi-camera pose estimation setup, extended with its "
+            "intrinsic and extrinsic calibration parameters. Link a CalibratedCamera (instead of a plain Device) "
+            "from a PoseEstimation object wherever calibration coordinates are available. Because it is a "
+            "Device, it is added once to the NWBFile (e.g., in general/devices) and can be linked to by "
+            "reference from multiple PoseEstimation objects (e.g., one per subject in a multi-subject recording "
+            "session), so the camera rig and its calibration are never duplicated."
+        ),
+        datasets=[
+            NWBDatasetSpec(
+                name="intrinsic_matrix",
+                doc="Intrinsic camera matrix K, encoding focal length and principal point. Shape (3, 3).",
+                dtype="float32",
+                shape=[3, 3],
+                quantity=1,
+            ),
+            NWBDatasetSpec(
+                name="rotation_matrix",
+                doc="Rotation matrix R mapping world coordinates to this camera's coordinate frame. Shape (3, 3).",
+                dtype="float32",
+                shape=[3, 3],
+                quantity="?",
+            ),
+            NWBDatasetSpec(
+                name="translation_vector",
+                doc="Translation vector t mapping world coordinates to this camera's coordinate frame. Shape (3,).",
+                dtype="float32",
+                dims=["x, y, z"],
+                shape=[3],
+                quantity="?",
+            ),
+            NWBDatasetSpec(
+                name="distortion_coefficients",
+                doc=(
+                    "Lens distortion coefficients for this camera. Length depends on the distortion model "
+                    "(typically 4 or 5 for radial-tangential)."
+                ),
+                dtype="float32",
+                dims=["num_distortion_params"],
+                shape=[None],
+                quantity="?",
+            ),
+        ],
+    )
+
+    multi_camera_pose_estimation = NWBGroupSpec(
+        neurodata_type_def="MultiCameraPoseEstimation",
+        neurodata_type_inc="NWBDataInterface",
+        doc=(
+            "Group that holds 3D pose estimation data computed from multiple synchronized cameras. Unlike "
+            "PoseEstimation (single-camera, pixel-space), this type stores keypoints in a shared 3D world-space "
+            "reference frame and organizes per-camera 2D data through PoseEstimation children, one per camera "
+            "view, each of which links to the camera Device (typically a CalibratedCamera, so that calibration "
+            "travels with the camera rather than being duplicated here). Designed for systems such as DANNCE or "
+            "Anipose that triangulate 3D positions from synchronized multi-camera footage."
+        ),
+        default_name="MultiCameraPoseEstimation",
+        groups=[
+            NWBGroupSpec(
+                neurodata_type_inc="PoseEstimationSeries",
+                doc=(
+                    "Estimated 3D position (x, y, z) of each body part in a shared world-space coordinate frame. "
+                    "The unit should be a physical length unit (e.g. 'meters' or 'millimeters'), not 'pixels'."
+                ),
+                quantity="*",
+            ),
+            NWBGroupSpec(
+                neurodata_type_inc="PoseEstimation",
+                doc=(
+                    "Per-camera 2D pose estimates, one PoseEstimation per camera view. Each PoseEstimation links "
+                    "to the camera Device (ideally a CalibratedCamera) used to record that view and, optionally, "
+                    "to that view's source video and 2D pose estimates in pixel space."
+                ),
+                quantity="*",
+            ),
+        ],
+        links=[
+            NWBLinkSpec(
+                target_type="Skeleton",
+                doc=(
+                    "Layout of body part locations and connections. The Skeleton object should be placed in a "
+                    "Skeletons object at the same level as this container."
+                ),
+                quantity="?",
+            ),
+        ],
+        datasets=[
+            NWBDatasetSpec(
+                name="description",
+                doc="Description of the pose estimation procedure and output.",
+                dtype="text",
+                quantity="?",
+            ),
+            NWBDatasetSpec(
+                name="scorer",
+                doc="Name of the scorer / algorithm used.",
+                dtype="text",
+                quantity="?",
+            ),
+            NWBDatasetSpec(
+                name="source_software",
+                doc="Name of the software tool used. Specifying the version attribute is strongly encouraged.",
+                dtype="text",
+                quantity="?",
+                attributes=[
+                    NWBAttributeSpec(
+                        name="version",
+                        doc="Version string of the software tool used.",
+                        dtype="text",
+                        required=False,
+                    ),
+                ],
+            ),
+        ],
+    )
+
     new_data_types = [
         skeleton,
         pose_estimation_series,
@@ -429,6 +559,8 @@ def main():
         source_videos,
         skeletons,
         pose_training,
+        calibrated_camera,
+        multi_camera_pose_estimation,
     ]
 
     # export the spec to yaml files in the spec folder


### PR DESCRIPTION
## Motivation

`src/spec/create_extension_spec.py` is the source of truth for the schema, but the YAML in `spec/` was updated by hand in #57. The generator still had no `CalibratedCamera` or `MultiCameraPoseEstimation`, and still described `PoseEstimation` as a multi-camera container with an unnamed `Device` link at `quantity: "*"`. Running it would have reverted the schema.

## Changes

`src/spec/create_extension_spec.py`:

- `PoseEstimation`: doc updated for the single-camera-view scoping; the unnamed `Device` link at `quantity: "*"` replaced by a named `device` link at `quantity: "?"`; `DEPRECATED.` prefixes added to the `original_videos`, `labeled_videos`, and `dimensions` docs; `source_video` and `labeled_video` docs reworded to match the schema.
- `CalibratedCamera` and `MultiCameraPoseEstimation` defined and appended to `new_data_types`, in the order the types appear in the schema.

`spec/ndx-pose.extensions.yaml` and `spec/ndx-pose.namespace.yaml` are regenerated from the script.

## Schema change

`CalibratedCamera.intrinsic_matrix` and `CalibratedCamera.rotation_matrix` gain `dims: [dim_0, dim_1]`. hdmf's `DatasetSpec.__init__` assigns those placeholder names to any dataset declared with a `shape` and no `dims`, so a dataset with a shape and no dimension names is not reachable from the generator. `dims` is descriptive and not validated, so this does not affect reading or writing.

Verified by parsing both YAML files and diffing the resulting dicts against `main`: this is the only difference in `ndx-pose.extensions.yaml`, and `ndx-pose.namespace.yaml` is unchanged.

## Formatting

The rest of the YAML diff is formatting. The previous file was passed through prettier; the regenerated file is ruamel output. Prettier's list indentation, `"?"` quoting, and line wrapping are not reachable from ruamel's configuration, and prettier preserves rather than reflows existing line breaks inside plain scalars, so its wrap positions cannot be regenerated at all.

Trailing whitespace is stripped from the two generated files. ruamel 0.19 changed `Emitter.write_plain` to decide a wrap when it reaches the word that would overflow `best_width`, rather than after crossing it. The separating space is already written to the stream by that point, so it is left at the end of the line. ruamel carries a `ToDo` for this.

## Testing

- `pytest src/pynwb/tests`: 58 passed, 309 subtests passed
- `ruff check src/`: passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)